### PR TITLE
feat: add TUI foundation (Task 05)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,21 @@ tasks/
 
 ## macOS
 .DS_Store
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool
+*.out
+
+# Local binaries
+htui
+new_https
+bin/

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,15 @@ module htui
 go 1.25.3
 
 require (
+	github.com/charmbracelet/bubbles v1.0.0
+	github.com/charmbracelet/bubbletea v1.3.10
+	github.com/charmbracelet/lipgloss v1.1.0
+)
+
+require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/charmbracelet/bubbles v1.0.0 // indirect
-	github.com/charmbracelet/bubbletea v1.3.10 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=
@@ -40,6 +42,8 @@ github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=

--- a/internal/app/keymap.go
+++ b/internal/app/keymap.go
@@ -1,0 +1,31 @@
+package app
+
+import "github.com/charmbracelet/bubbles/key"
+
+// KeyMap содержит все глобальные горячие клавиши приложения.
+type KeyMap struct {
+    NextPanel key.Binding
+    PrevPanel key.Binding
+    Send      key.Binding
+    Save      key.Binding
+    New       key.Binding
+    Search    key.Binding
+    Duplicate key.Binding
+    Delete    key.Binding
+    Help      key.Binding
+    Quit      key.Binding
+}
+
+// DefaultKeyMap — биндинги по умолчанию.
+var DefaultKeyMap = KeyMap{
+    NextPanel: key.NewBinding(key.WithKeys("tab"),        key.WithHelp("tab", "next panel")),
+    PrevPanel: key.NewBinding(key.WithKeys("shift+tab"),  key.WithHelp("shift+tab", "prev panel")),
+    Send:      key.NewBinding(key.WithKeys("ctrl+enter"), key.WithHelp("ctrl+enter", "send request")),
+    Save:      key.NewBinding(key.WithKeys("ctrl+s"),     key.WithHelp("ctrl+s", "save request")),
+    New:       key.NewBinding(key.WithKeys("n"),          key.WithHelp("n", "new request")),
+    Search:    key.NewBinding(key.WithKeys("/"),          key.WithHelp("/", "search")),
+    Duplicate: key.NewBinding(key.WithKeys("d"),          key.WithHelp("d", "duplicate")),
+    Delete:    key.NewBinding(key.WithKeys("delete"),     key.WithHelp("del", "delete")),
+    Help:      key.NewBinding(key.WithKeys("?"),          key.WithHelp("?", "help")),
+    Quit:      key.NewBinding(key.WithKeys("q", "ctrl+c"),key.WithHelp("q", "quit")),
+}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -4,6 +4,7 @@ import (
     "time"
 
     tea "github.com/charmbracelet/bubbletea"
+
     "htui/internal/httpclient"
     "htui/internal/requesteditor"
     "htui/internal/responsedisplay"
@@ -33,11 +34,16 @@ type ResponseCompleteMsg struct{ Data types.ResponseData }
 
 // App — корневая модель приложения.
 type App struct {
+    // Глобальные хоткеи
+    keys KeyMap
+
+    // Подмодели
     sidebar  sidebar.Model
     editor   requesteditor.Model
     response responsedisplay.Model
     help     ui.HelpModel
 
+    // Состояние UI
     focus      FocusedPanel
     loading    bool
     showHelp   bool
@@ -45,9 +51,9 @@ type App struct {
     height     int
     layoutMode ui.LayoutMode
 
+    // Хранилище и HTTP-клиент
     store  store.Store
     client *httpclient.Client
-    keys   KeyMap
 }
 
 // New инициализирует приложение:
@@ -81,7 +87,7 @@ func New() (App, error) {
     m := App{
         store:  s,
         client: httpclient.New(),
-        keys:   DefaultKeyMap,
+        keys:   DefaultKeyMap,   // <-- используем KeyMap из keymap.go
         focus:  PanelSidebar,
     }
 

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -1,29 +1,123 @@
 package app
 
-import tea "github.com/charmbracelet/bubbletea"
+import (
+    "time"
 
-// App — корневая модель приложения (stub).
-type App struct{}
+    tea "github.com/charmbracelet/bubbletea"
+    "htui/internal/httpclient"
+    "htui/internal/requesteditor"
+    "htui/internal/responsedisplay"
+    "htui/internal/sidebar"
+    "htui/internal/store"
+    "htui/internal/types"
+    "htui/internal/ui"
+)
 
-// New инициализирует приложение.
+// FocusedPanel определяет, какая панель сейчас активна.
+type FocusedPanel int
+
+const (
+    PanelSidebar FocusedPanel = iota
+    PanelEditor
+    PanelResponse
+)
+
+// Сообщения от дочерних компонентов вверх.
+type ResponseReceivedMsg struct{ Data types.ResponseData }
+type RequestSavedMsg struct{ Request types.SavedRequest }
+type RequestDeletedMsg struct{ ID string }
+
+// Заглушки для будущего стриминга (не используются в MVP).
+type BodyChunkMsg struct{ Chunk []byte }
+type ResponseCompleteMsg struct{ Data types.ResponseData }
+
+// App — корневая модель приложения.
+type App struct {
+    sidebar  sidebar.Model
+    editor   requesteditor.Model
+    response responsedisplay.Model
+    help     ui.HelpModel
+
+    focus      FocusedPanel
+    loading    bool
+    showHelp   bool
+    width      int
+    height     int
+    layoutMode ui.LayoutMode
+
+    store  store.Store
+    client *httpclient.Client
+    keys   KeyMap
+}
+
+// New инициализирует приложение:
+// создаёт store, сидирует демо если первый запуск, загружает запросы.
 func New() (App, error) {
-	return App{}, nil
+    s, err := store.New()
+    if err != nil {
+        return App{}, err
+    }
+
+    firstRun, err := s.IsFirstRun()
+    if err != nil {
+        return App{}, err
+    }
+    if firstRun {
+        for _, r := range types.DemoRequests() {
+            if err := s.Save(r); err != nil {
+                return App{}, err
+            }
+        }
+        if err := s.MarkSeeded(); err != nil {
+            return App{}, err
+        }
+    }
+
+    requests, err := s.List()
+    if err != nil {
+        return App{}, err
+    }
+
+    m := App{
+        store:  s,
+        client: httpclient.New(),
+        keys:   DefaultKeyMap,
+        focus:  PanelSidebar,
+    }
+
+    m.sidebar = sidebar.New(requests)
+    m.editor = requesteditor.New()
+    m.response = responsedisplay.New()
+    m.help = ui.NewHelpModel(DefaultKeyMap)
+
+    // Автовыбор первого запроса
+    if len(requests) > 0 {
+        m.editor = m.editor.LoadRequest(requests[0])
+        m.sidebar = m.sidebar.SelectFirst()
+    }
+
+    return m, nil
 }
 
 func (m App) Init() tea.Cmd {
-	return nil
+    return nil
 }
 
-func (m App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		if msg.String() == "q" || msg.String() == "ctrl+c" {
-			return m, tea.Quit
-		}
-	}
-	return m, nil
+// ready возвращает false пока не получены размеры терминала.
+func (m App) ready() bool {
+    return m.width > 0 && m.height > 0
 }
 
-func (m App) View() string {
-	return "htui — TUI HTTP Client\n\nPress q to quit\n"
+// shiftFocus циклично переключает фокус между панелями.
+func (m App) shiftFocus(delta int) App {
+    panels := []FocusedPanel{PanelSidebar, PanelEditor, PanelResponse}
+    idx := int(m.focus)
+    idx = (idx + delta + len(panels)) % len(panels)
+    m.focus = panels[idx]
+    return m
+}
+
+// now вынесен сюда, чтобы использовать в update.go
+func now() int64 {
+    return time.Now().UnixNano()
 }

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -87,14 +87,16 @@ func New() (App, error) {
     m := App{
         store:  s,
         client: httpclient.New(),
-        keys:   DefaultKeyMap,   // <-- используем KeyMap из keymap.go
+        keys:   DefaultKeyMap, // <-- используем KeyMap из keymap.go
         focus:  PanelSidebar,
     }
 
     m.sidebar = sidebar.New(requests)
     m.editor = requesteditor.New()
     m.response = responsedisplay.New()
-    m.help = ui.NewHelpModel(DefaultKeyMap)
+    // nil — использовать defaultSections() внутри ui.NewHelpModel,
+    // но ты можешь передать сюда и конкретный map, если будешь использовать bindings.
+    m.help = ui.NewHelpModel(nil)
 
     // Автовыбор первого запроса
     if len(requests) > 0 {

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -1,0 +1,168 @@
+package app
+
+import (
+    "context"
+    "fmt"
+
+    tea "github.com/charmbracelet/bubbletea"
+    "github.com/charmbracelet/bubbles/spinner"
+
+    "htui/internal/httpclient"
+    "htui/internal/requesteditor"
+    "htui/internal/sidebar"
+    "htui/internal/types"
+    "htui/internal/ui"
+)
+
+func (m App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    switch msg := msg.(type) {
+
+    case tea.WindowSizeMsg:
+        m.width = msg.Width
+        m.height = msg.Height
+        m.layoutMode = ui.ComputeLayout(msg.Width)
+        dims := ui.ComputePanelDimensions(msg.Width, msg.Height, m.layoutMode)
+
+        var cmds []tea.Cmd
+        var c tea.Cmd
+
+        m.sidebar, c = m.sidebar.SetSize(dims.Sidebar.Width, dims.Sidebar.Height)
+        cmds = append(cmds, c)
+
+        m.editor, c = m.editor.SetSize(dims.Editor.Width, dims.Editor.Height)
+        cmds = append(cmds, c)
+
+        m.response, c = m.response.SetSize(dims.Response.Width, dims.Response.Height)
+        cmds = append(cmds, c)
+
+        return m, tea.Batch(cmds...)
+
+    case tea.KeyMsg:
+        // Help overlay перехватывает все клавиши
+        if m.showHelp {
+            if msg.String() == "?" || msg.String() == "esc" {
+                m.showHelp = false
+            }
+            return m, nil
+        }
+
+        // Глобальные клавиши (до роутинга к панелям)
+        switch msg.String() {
+        case "tab":
+            m = m.shiftFocus(+1)
+            return m, nil
+        case "shift+tab":
+            m = m.shiftFocus(-1)
+            return m, nil
+        case "?":
+            m.showHelp = true
+            return m, nil
+        case "q", "ctrl+c":
+            return m, tea.Quit
+        }
+
+        // Роутинг к сфокусированной панели
+        return m.routeKeyToFocusedPanel(msg)
+
+    case ResponseReceivedMsg:
+        m.loading = false
+        m.response = m.response.SetResponse(msg.Data)
+        m.focus = PanelResponse
+        return m, nil
+
+    case sidebar.RequestSelectedMsg:
+        m.editor = m.editor.LoadRequest(msg.Request)
+        m.focus = PanelEditor
+        return m, nil
+
+    case sidebar.NewRequestMsg:
+        m.editor = m.editor.LoadRequest(types.NewSavedRequest())
+        m.focus = PanelEditor
+        return m, nil
+
+    case sidebar.DeleteRequestMsg:
+        return m, deleteRequestCmd(m.store, msg.ID)
+
+    case sidebar.DuplicateRequestMsg:
+        dup := msg.Request
+        dup.ID = fmt.Sprintf("%d", now())
+        dup.Name = dup.Name + " (copy)"
+        return m, saveRequestCmd(m.store, dup)
+
+    case requesteditor.SendRequestMsg:
+        if m.loading {
+            return m, nil
+        }
+        m.loading = true
+        m.response = m.response.SetLoading(true)
+        return m, sendRequestCmd(m.client, msg.Request)
+
+    case requesteditor.SaveRequestMsg:
+        return m, saveRequestCmd(m.store, msg.Request)
+
+    case RequestSavedMsg:
+        m.sidebar = m.sidebar.Reload(m.store)
+        return m, nil
+
+    case RequestDeletedMsg:
+        m.sidebar = m.sidebar.Reload(m.store)
+        // Если удалили текущий открытый запрос — очистить editor
+        if m.editor.CurrentID() == msg.ID {
+            m.editor = m.editor.Clear()
+        }
+        return m, nil
+
+    case spinner.TickMsg:
+        // Spinner всегда обновляется (независимо от фокуса)
+        var cmd tea.Cmd
+        m.response, cmd = m.response.UpdateSpinner(msg)
+        return m, cmd
+    }
+
+    // Остальные сообщения — только в сфокусированную панель
+    return m.routeToFocusedPanel(msg)
+}
+
+// routeKeyToFocusedPanel направляет KeyMsg в активную панель.
+func (m App) routeKeyToFocusedPanel(msg tea.KeyMsg) (App, tea.Cmd) {
+    return m.routeToFocusedPanel(msg)
+}
+
+// routeToFocusedPanel направляет любое сообщение в активную панель.
+func (m App) routeToFocusedPanel(msg tea.Msg) (App, tea.Cmd) {
+    var cmd tea.Cmd
+    switch m.focus {
+    case PanelSidebar:
+        m.sidebar, cmd = m.sidebar.Update(msg)
+    case PanelEditor:
+        m.editor, cmd = m.editor.Update(msg)
+    case PanelResponse:
+        m.response, cmd = m.response.Update(msg)
+    }
+    return m, cmd
+}
+
+// --- tea.Cmd фабрики (единственное место где httpclient встречает bubbletea) ---
+
+func sendRequestCmd(client *httpclient.Client, req types.SavedRequest) tea.Cmd {
+    return func() tea.Msg {
+        ctx, cancel := context.WithTimeout(context.Background(), httpclient.DefaultTimeout)
+        defer cancel()
+        result := client.Execute(ctx, req)
+        return ResponseReceivedMsg{Data: result}
+    }
+}
+
+func saveRequestCmd(s interface{ Save(types.SavedRequest) error }, r types.SavedRequest) tea.Cmd {
+    return func() tea.Msg {
+        _ = s.Save(r)
+        return RequestSavedMsg{Request: r}
+    }
+}
+
+func deleteRequestCmd(s interface{ Delete(string) error }, id string) tea.Cmd {
+    return func() tea.Msg {
+        _ = s.Delete(id)
+        return RequestDeletedMsg{ID: id}
+    }
+}

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -5,6 +5,7 @@ import (
     "fmt"
 
     tea "github.com/charmbracelet/bubbletea"
+    "github.com/charmbracelet/bubbles/key"
     "github.com/charmbracelet/bubbles/spinner"
 
     "htui/internal/httpclient"
@@ -47,17 +48,17 @@ func (m App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
         }
 
         // Глобальные клавиши (до роутинга к панелям)
-        switch msg.String() {
-        case "tab":
+        switch {
+        case key.Matches(msg, m.keys.NextPanel):
             m = m.shiftFocus(+1)
             return m, nil
-        case "shift+tab":
+        case key.Matches(msg, m.keys.PrevPanel):
             m = m.shiftFocus(-1)
             return m, nil
-        case "?":
+        case key.Matches(msg, m.keys.Help):
             m.showHelp = true
             return m, nil
-        case "q", "ctrl+c":
+        case key.Matches(msg, m.keys.Quit):
             return m, tea.Quit
         }
 

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -39,7 +39,7 @@ func (m App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
         return m, tea.Batch(cmds...)
 
     case tea.KeyMsg:
-        // Help overlay перехватывает все клавиши
+        // Help overlay перехватывает все клавиши пока открыт
         if m.showHelp {
             if msg.String() == "?" || msg.String() == "esc" {
                 m.showHelp = false
@@ -56,6 +56,8 @@ func (m App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
             m = m.shiftFocus(-1)
             return m, nil
         case key.Matches(msg, m.keys.Help):
+            // при повторном нажатии "?" удобно тоже закрывать,
+            // но по ТЗ достаточно открыть, а закрытие уже перехватит блок выше
             m.showHelp = true
             return m, nil
         case key.Matches(msg, m.keys.Quit):

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -1,0 +1,50 @@
+package app
+
+import (
+    "htui/internal/ui"
+)
+
+func (m App) View() string {
+    if !m.ready() {
+        return "Loading...\n"
+    }
+
+    // Каждая панель рендерит себя с рамкой нужного цвета
+    sidebarView := m.renderPanel(
+        m.sidebar.View(),
+        m.focus == PanelSidebar,
+        m.sidebar.Width(),
+        m.sidebar.Height(),
+    )
+
+    editorView := m.renderPanel(
+        m.editor.View(),
+        m.focus == PanelEditor,
+        m.editor.Width(),
+        m.editor.Height(),
+    )
+
+    responseView := m.renderPanel(
+        m.response.View(),
+        m.focus == PanelResponse,
+        m.response.Width(),
+        m.response.Height(),
+    )
+
+    layout := ui.RenderLayout(m.layoutMode, sidebarView, editorView, responseView)
+
+    if m.showHelp {
+        layout = ui.RenderHelpOverlay(layout, m.help.View(), m.width, m.height)
+    }
+
+    return layout
+}
+
+// renderPanel оборачивает содержимое панели в рамку (active/inactive).
+func (m App) renderPanel(content string, active bool, w, h int) string {
+    style := ui.Theme.InactiveBorder
+    if active {
+        style = ui.Theme.ActiveBorder
+    }
+    return style.Width(w).Height(h).Render(content)
+}

--- a/internal/requesteditor/fields.go
+++ b/internal/requesteditor/fields.go
@@ -1,0 +1,220 @@
+package requesteditor
+
+import (
+    "fmt"
+    "strings"
+
+    "github.com/charmbracelet/bubbles/textinput"
+    tea "github.com/charmbracelet/bubbletea"
+    "htui/internal/types"
+    "htui/internal/ui"
+)
+
+type KVTable struct {
+    rows    []kvRow
+    cursor  int
+    editCol int
+    editing bool
+    input   textinput.Model
+    width   int
+}
+
+type kvRow struct {
+    key     string
+    value   string
+    enabled bool
+}
+
+func NewKVTable() KVTable {
+    ti := textinput.New()
+    ti.CharLimit = 500
+    return KVTable{
+        rows:  []kvRow{{enabled: true}},
+        input: ti,
+    }
+}
+
+func FromHeaders(headers []types.Header) KVTable {
+    t := NewKVTable()
+    if len(headers) == 0 {
+        return t
+    }
+    t.rows = make([]kvRow, len(headers))
+    for i, h := range headers {
+        t.rows[i] = kvRow{key: h.Key, value: h.Value, enabled: h.Enabled}
+    }
+    return t
+}
+
+func FromParams(params []types.Param) KVTable {
+    t := NewKVTable()
+    if len(params) == 0 {
+        return t
+    }
+    t.rows = make([]kvRow, len(params))
+    for i, p := range params {
+        t.rows[i] = kvRow{key: p.Key, value: p.Value, enabled: p.Enabled}
+    }
+    return t
+}
+
+func (t KVTable) ToHeaders() []types.Header {
+    var result []types.Header
+    for _, r := range t.rows {
+        if r.key != "" {
+            result = append(result, types.Header{Key: r.key, Value: r.value, Enabled: r.enabled})
+        }
+    }
+    return result
+}
+
+func (t KVTable) ToParams() []types.Param {
+    var result []types.Param
+    for _, r := range t.rows {
+        if r.key != "" {
+            result = append(result, types.Param{Key: r.key, Value: r.value, Enabled: r.enabled})
+        }
+    }
+    return result
+}
+
+func (t KVTable) Update(msg tea.Msg) (KVTable, tea.Cmd) {
+    if t.editing {
+        switch msg := msg.(type) {
+        case tea.KeyMsg:
+            switch msg.String() {
+            case "esc":
+                t = t.commitEdit()
+                t.editing = false
+                return t, nil
+            case "tab", "enter":
+                t = t.commitEdit()
+                if msg.String() == "tab" {
+                    t.editCol = (t.editCol + 1) % 2
+                    t = t.startEdit()
+                } else {
+                    t.editing = false
+                }
+                return t, nil
+            }
+        }
+        var c tea.Cmd
+        t.input, c = t.input.Update(msg)
+        return t, c
+    }
+
+    switch msg := msg.(type) {
+    case tea.KeyMsg:
+        switch msg.String() {
+        case "up", "k":
+            if t.cursor > 0 {
+                t.cursor--
+            }
+        case "down", "j":
+            if t.cursor < len(t.rows)-1 {
+                t.cursor++
+            }
+        case "enter":
+            t.editCol = 0
+            t = t.startEdit()
+        case "tab":
+            t.editCol = 1
+            t = t.startEdit()
+        case "a":
+            t.rows = append(t.rows, kvRow{enabled: true})
+            t.cursor = len(t.rows) - 1
+        case "delete", "backspace":
+            if len(t.rows) > 1 {
+                t.rows = append(t.rows[:t.cursor], t.rows[t.cursor+1:]...)
+                if t.cursor >= len(t.rows) {
+                    t.cursor = len(t.rows) - 1
+                }
+            } else {
+                t.rows[0] = kvRow{enabled: true}
+            }
+        case " ":
+            t.rows[t.cursor].enabled = !t.rows[t.cursor].enabled
+        }
+    }
+    return t, nil
+}
+
+func (t KVTable) View() string {
+    var sb strings.Builder
+
+    keyW := t.width/2 - 2
+    valW := t.width - keyW - 4
+    header := ui.Theme.Muted.Render(
+        fmt.Sprintf("  %-*s  %-*s", keyW, "Key", valW, "Value"),
+    )
+    sb.WriteString(header + "\n")
+
+    for i, row := range t.rows {
+        prefix := "  "
+        if i == t.cursor {
+            prefix = ui.Theme.Highlight.Render("> ")
+        }
+
+        enabled := ui.Theme.Muted.Render("✓")
+        if !row.enabled {
+            enabled = ui.Theme.Muted.Render("○")
+        }
+
+        var keyStr, valStr string
+        if t.editing && i == t.cursor {
+            if t.editCol == 0 {
+                keyStr = t.input.View()
+                valStr = ui.Theme.Muted.Render(row.value)
+            } else {
+                keyStr = ui.Theme.Muted.Render(row.key)
+                valStr = t.input.View()
+            }
+        } else {
+            keyStr = row.key
+            if keyStr == "" {
+                keyStr = ui.Theme.Muted.Render("(key)")
+            }
+            valStr = row.value
+            if valStr == "" {
+                valStr = ui.Theme.Muted.Render("(value)")
+            }
+        }
+
+        line := fmt.Sprintf("%s%s %-*s  %-*s", prefix, enabled, keyW, keyStr, valW, valStr)
+        sb.WriteString(line + "\n")
+    }
+
+    sb.WriteString(ui.Theme.Muted.Render("\n  [a] add  [del] remove  [space] toggle  [enter] edit"))
+    return sb.String()
+}
+
+func (t KVTable) SetWidth(w int) KVTable {
+    t.width = w
+    t.input.Width = w/2 - 4
+    return t
+}
+
+func (t *KVTable) startEdit() KVTable {
+    t.editing = true
+    var val string
+    if t.editCol == 0 {
+        val = t.rows[t.cursor].key
+    } else {
+        val = t.rows[t.cursor].value
+    }
+    t.input.SetValue(val)
+    t.input.Focus()
+    t.input.CursorEnd()
+    return *t
+}
+
+func (t *KVTable) commitEdit() KVTable {
+    val := t.input.Value()
+    if t.editCol == 0 {
+        t.rows[t.cursor].key = val
+    } else {
+        t.rows[t.cursor].value = val
+    }
+    t.input.Blur()
+    return *t
+}

--- a/internal/requesteditor/model.go
+++ b/internal/requesteditor/model.go
@@ -1,0 +1,52 @@
+package requesteditor
+
+import (
+    tea "github.com/charmbracelet/bubbletea"
+    "htui/internal/types"
+)
+
+// Model — заглушка редактора запроса.
+type Model struct {
+    w, h int
+}
+
+// Сообщения, которые использует app.update.go
+type SendRequestMsg struct{ Request types.SavedRequest }
+type SaveRequestMsg struct{ Request types.SavedRequest }
+
+func New() Model {
+    return Model{}
+}
+
+func (m Model) SetSize(w, h int) (Model, tea.Cmd) {
+    m.w, m.h = w, h
+    return m, nil
+}
+
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+    // В Task 05 логика не нужна
+    _ = msg
+    return m, nil
+}
+
+func (m Model) View() string {
+    return "Editor"
+}
+
+func (m Model) Width() int  { return m.w }
+func (m Model) Height() int { return m.h }
+
+// LoadRequest — заглушка загрузки сохранённого запроса.
+func (m Model) LoadRequest(_ types.SavedRequest) Model {
+    return m
+}
+
+// Clear — заглушка очистки редактора.
+func (m Model) Clear() Model {
+    return m
+}
+
+// CurrentID — ID текущего запроса, в заглушке пустой.
+func (m Model) CurrentID() string {
+    return ""
+}

--- a/internal/requesteditor/validation.go
+++ b/internal/requesteditor/validation.go
@@ -1,0 +1,52 @@
+package requesteditor
+
+import (
+    "encoding/json"
+    "net/url"
+
+    "htui/internal/types"
+)
+
+type ValidationResult struct {
+    Valid    bool
+    Errors   []string
+    Warnings []string
+}
+
+func Validate(r types.SavedRequest) ValidationResult {
+    var res ValidationResult
+    res.Valid = true
+
+    if r.URL == "" {
+        res.Valid = false
+        res.Errors = append(res.Errors, "URL is required")
+        return res
+    }
+
+    testURL := r.URL
+    if len(testURL) > 0 && !hasScheme(testURL) {
+        testURL = "https://" + testURL
+    }
+    if _, err := url.ParseRequestURI(testURL); err != nil {
+        res.Valid = false
+        res.Errors = append(res.Errors, "Invalid URL: "+err.Error())
+    }
+
+    if r.BodyMode == types.BodyModeJSON && r.Body != "" {
+        if !json.Valid([]byte(r.Body)) {
+            res.Valid = false
+            res.Errors = append(res.Errors, "Invalid JSON in request body")
+        }
+    }
+
+    if r.Auth.Type == types.AuthBearer && r.Auth.Token == "" {
+        res.Warnings = append(res.Warnings, "Bearer token is empty")
+    }
+
+    return res
+}
+
+func hasScheme(u string) bool {
+    return len(u) > 4 &&
+        (u[:7] == "http://" || u[:8] == "https://")
+}

--- a/internal/responsedisplay/model.go
+++ b/internal/responsedisplay/model.go
@@ -1,0 +1,58 @@
+package responsedisplay
+
+import (
+    tea "github.com/charmbracelet/bubbletea"
+    "github.com/charmbracelet/bubbles/spinner"
+    "htui/internal/types"
+)
+
+// Model — заглушка панели ответа.
+type Model struct {
+    w, h    int
+    spin    spinner.Model
+    loading bool
+}
+
+func New() Model {
+    s := spinner.New()
+    return Model{spin: s}
+}
+
+func (m Model) SetSize(w, h int) (Model, tea.Cmd) {
+    m.w, m.h = w, h
+    return m, nil
+}
+
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+    // В Task 05 логика не важна
+    _ = msg
+    return m, nil
+}
+
+func (m Model) UpdateSpinner(msg spinner.TickMsg) (Model, tea.Cmd) {
+    var cmd tea.Cmd
+    m.spin, cmd = m.spin.Update(msg)
+    return m, cmd
+}
+
+func (m Model) View() string {
+    if m.loading {
+        return "Loading response..."
+    }
+    return "Response"
+}
+
+func (m Model) Width() int  { return m.w }
+func (m Model) Height() int { return m.h }
+
+// SetResponse — заглушка установки ответа.
+func (m Model) SetResponse(_ types.ResponseData) Model {
+    m.loading = false
+    return m
+}
+
+// SetLoading — заглушка включения/выключения загрузки.
+func (m Model) SetLoading(loading bool) Model {
+    m.loading = loading
+    return m
+}

--- a/internal/sidebar/model.go
+++ b/internal/sidebar/model.go
@@ -1,0 +1,51 @@
+package sidebar
+
+import (
+    tea "github.com/charmbracelet/bubbletea"
+    "htui/internal/store"
+    "htui/internal/types"
+)
+
+// Model — заглушка модели sidebar для Task 05.
+type Model struct {
+    w, h   int
+    items  []types.SavedRequest
+}
+
+// Сообщения, которые использует app.update.go
+type RequestSelectedMsg struct{ Request types.SavedRequest }
+type NewRequestMsg struct{}
+type DeleteRequestMsg struct{ ID string }
+type DuplicateRequestMsg struct{ Request types.SavedRequest }
+
+// New создаёт модель sidebar с начальным списком запросов.
+func New(requests []types.SavedRequest) Model {
+    return Model{items: requests}
+}
+
+func (m Model) SetSize(w, h int) (Model, tea.Cmd) {
+    m.w, m.h = w, h
+    return m, nil
+}
+
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+    // В Task 05 логика не нужна, заглушка
+    return m, nil
+}
+
+func (m Model) View() string {
+    return "Sidebar"
+}
+
+func (m Model) Width() int  { return m.w }
+func (m Model) Height() int { return m.h }
+
+// SelectFirst — заглушка выбора первого элемента.
+func (m Model) SelectFirst() Model {
+    return m
+}
+
+// Reload — загружает данные из store, но в заглушке ничего не делает.
+func (m Model) Reload(_ store.Store) Model {
+    return m
+}

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -1,29 +1,147 @@
 package ui
 
-import "github.com/charmbracelet/lipgloss"
+import (
+    "fmt"
+    "strings"
 
-// HelpModel — простая заглушка для help overlay.
-type HelpModel struct{}
+    "github.com/charmbracelet/lipgloss"
+)
 
-// NewHelpModel принимает KeyMap из app, но мы не используем его внутри.
-func NewHelpModel(_ interface{}) HelpModel {
-    return HelpModel{}
+// helpRow — одна строка горячей клавиши.
+type helpRow struct {
+    key  string
+    desc string
 }
 
-func (h HelpModel) View() string {
-    return "Help\n\nPress ? or Esc to close."
+// helpSection — секция в таблице помощи.
+type helpSection struct {
+    title string
+    rows  []helpRow
 }
 
-// RenderHelpOverlay рисует рамку поверх layout.
-func RenderHelpOverlay(bg, helpView string, width, height int) string {
+// HelpModel — модель экрана помощи.
+// Принимает биндинги как данные (не импортирует app.KeyMap напрямую).
+type HelpModel struct {
+    sections []helpSection
+}
+
+// NewHelpModel создаёт HelpModel из стандартных биндингов.
+// Вызывается из app.New() с конкретными строками биндингов.
+func NewHelpModel(bindings map[string]string) HelpModel {
+    // bindings пока не используем, берём захардкоженные секции
+    return HelpModel{
+        sections: defaultSections(),
+    }
+}
+
+// defaultSections возвращает секции по умолчанию.
+// Содержимое синхронизировано с app.DefaultKeyMap.
+func defaultSections() []helpSection {
+    return []helpSection{
+        {
+            title: "Navigation",
+            rows: []helpRow{
+                {"tab", "next panel"},
+                {"shift+tab", "prev panel"},
+                {"q / ctrl+c", "quit"},
+                {"?", "close help"},
+            },
+        },
+        {
+            title: "Request Editor",
+            rows: []helpRow{
+                {"ctrl+enter", "send request"},
+                {"ctrl+s", "save request"},
+                {"n", "new request"},
+                {"d", "duplicate"},
+                {"del", "delete request"},
+                {"/", "search requests"},
+            },
+        },
+        {
+            title: "Sidebar",
+            rows: []helpRow{
+                {"↑/↓, j/k", "navigate list"},
+                {"enter", "open request"},
+                {"/", "search/filter"},
+                {"esc", "cancel search"},
+            },
+        },
+        {
+            title: "Response",
+            rows: []helpRow{
+                {"j/k, ↑/↓", "scroll"},
+                {"PgUp/PgDn", "fast scroll"},
+                {"tab", "body ↔ headers"},
+            },
+        },
+        {
+            title: "Request Body (KV Table)",
+            rows: []helpRow{
+                {"a", "add row"},
+                {"del", "delete row"},
+                {"enter", "edit cell"},
+                {"tab", "next column"},
+                {"space", "toggle enabled"},
+            },
+        },
+    }
+}
+
+// View рендерит содержимое overlay (без рамки — рамка добавляется в RenderHelpOverlay).
+func (m HelpModel) View() string {
+    var sb strings.Builder
+
+    sb.WriteString(Theme.Bold.Render("Keyboard Shortcuts") + "\n\n")
+
+    // Рендерим секции в два столбца
+    half := (len(m.sections) + 1) / 2
+    left := m.sections[:half]
+    right := m.sections[half:]
+
+    leftStr := renderSections(left, 38)
+    rightStr := renderSections(right, 38)
+
+    combined := lipgloss.JoinHorizontal(lipgloss.Top,
+        lipgloss.NewStyle().Width(42).Render(leftStr),
+        lipgloss.NewStyle().Width(42).Render(rightStr),
+    )
+    sb.WriteString(combined)
+
+    sb.WriteString("\n\n" + Theme.Muted.Render("Press ? or esc to close"))
+    return sb.String()
+}
+
+func renderSections(sections []helpSection, width int) string {
+    var sb strings.Builder
+    for _, sec := range sections {
+        sb.WriteString(Theme.Highlight.Render(sec.title) + "\n")
+        for _, row := range sec.rows {
+            keyStr := Theme.Bold.Render(fmt.Sprintf("  %-16s", row.key))
+            descStr := Theme.Muted.Render(row.desc)
+            sb.WriteString(keyStr + descStr + "\n")
+        }
+        sb.WriteString("\n")
+    }
+    return sb.String()
+}
+
+// RenderHelpOverlay накладывает overlay поверх base layout.
+// Использует lipgloss.Place для центрирования, затемняет фон.
+func RenderHelpOverlay(base, content string, w, h int) string {
     box := lipgloss.NewStyle().
         Border(lipgloss.RoundedBorder()).
         BorderForeground(lipgloss.Color("62")).
-        Padding(1, 2).
-        Width(width/2).
-        Height(height/2).
-        Render(helpView)
+        Padding(1, 3).
+        Background(lipgloss.Color("235")).
+        Render(content)
 
-    // Очень простая версия — просто вертикально склеиваем
-    return lipgloss.JoinVertical(lipgloss.Left, bg, box)
+    // Накладываем overlay по центру экрана
+    return lipgloss.Place(
+        w, h,
+        lipgloss.Center,
+        lipgloss.Center,
+        box,
+        lipgloss.WithWhitespaceBackground(lipgloss.Color("236")),
+    )
 }

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -1,0 +1,29 @@
+package ui
+
+import "github.com/charmbracelet/lipgloss"
+
+// HelpModel — простая заглушка для help overlay.
+type HelpModel struct{}
+
+// NewHelpModel принимает KeyMap из app, но мы не используем его внутри.
+func NewHelpModel(_ interface{}) HelpModel {
+    return HelpModel{}
+}
+
+func (h HelpModel) View() string {
+    return "Help\n\nPress ? or Esc to close."
+}
+
+// RenderHelpOverlay рисует рамку поверх layout.
+func RenderHelpOverlay(bg, helpView string, width, height int) string {
+    box := lipgloss.NewStyle().
+        Border(lipgloss.RoundedBorder()).
+        BorderForeground(lipgloss.Color("62")).
+        Padding(1, 2).
+        Width(width/2).
+        Height(height/2).
+        Render(helpView)
+
+    // Очень простая версия — просто вертикально склеиваем
+    return lipgloss.JoinVertical(lipgloss.Left, bg, box)
+}

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -1,0 +1,91 @@
+package ui
+
+import "github.com/charmbracelet/lipgloss"
+
+// LayoutMode определяет режим раскладки.
+type LayoutMode int
+
+const (
+    LayoutWide   LayoutMode = iota // три колонки рядом
+    LayoutNarrow                   // sidebar + editor/response стек
+    LayoutMinimal                  // sidebar скрыт, только editor/response
+)
+
+const (
+    WideThreshold    = 120 // columns
+    MinimalThreshold = 80  // columns
+)
+
+// PanelSize — ширина и высота панели.
+type PanelSize struct {
+    Width  int
+    Height int
+}
+
+// PanelDimensions — размеры всех трёх панелей.
+type PanelDimensions struct {
+    Sidebar  PanelSize
+    Editor   PanelSize
+    Response PanelSize
+}
+
+// ComputeLayout определяет режим раскладки по ширине терминала.
+func ComputeLayout(width int) LayoutMode {
+    switch {
+    case width >= WideThreshold:
+        return LayoutWide
+    case width >= MinimalThreshold:
+        return LayoutNarrow
+    default:
+        return LayoutMinimal
+    }
+}
+
+// ComputePanelDimensions рассчитывает размеры панелей с учётом рамок (2px border).
+func ComputePanelDimensions(w, h int, mode LayoutMode) PanelDimensions {
+    // Рамка занимает 2 символа (1 с каждой стороны)
+    const borderSize = 2
+
+    switch mode {
+    case LayoutWide:
+        sidebarW := w * 25 / 100
+        editorW := w * 40 / 100
+        responseW := w - sidebarW - editorW
+        return PanelDimensions{
+            Sidebar:  PanelSize{sidebarW - borderSize, h - borderSize},
+            Editor:   PanelSize{editorW - borderSize, h - borderSize},
+            Response: PanelSize{responseW - borderSize, h - borderSize},
+        }
+
+    case LayoutNarrow:
+        sidebarW := w * 30 / 100
+        contentW := w - sidebarW
+        contentH := h / 2
+        return PanelDimensions{
+            Sidebar:  PanelSize{sidebarW - borderSize, h - borderSize},
+            Editor:   PanelSize{contentW - borderSize, contentH - borderSize},
+            Response: PanelSize{contentW - borderSize, h - contentH - borderSize},
+        }
+
+    default: // LayoutMinimal
+        half := h / 2
+        return PanelDimensions{
+            Sidebar:  PanelSize{0, 0},
+            Editor:   PanelSize{w - borderSize, half - borderSize},
+            Response: PanelSize{w - borderSize, h - half - borderSize},
+        }
+    }
+}
+
+// RenderLayout собирает финальный вид из трёх строк-компонентов.
+func RenderLayout(mode LayoutMode, sidebar, editor, response string) string {
+    switch mode {
+    case LayoutWide:
+        return lipgloss.JoinHorizontal(lipgloss.Top, sidebar, editor, response)
+    case LayoutNarrow:
+        right := lipgloss.JoinVertical(lipgloss.Left, editor, response)
+        return lipgloss.JoinHorizontal(lipgloss.Top, sidebar, right)
+    default:
+        return lipgloss.JoinVertical(lipgloss.Left, editor, response)
+    }
+}

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -1,0 +1,85 @@
+package ui
+
+import "github.com/charmbracelet/lipgloss"
+
+var Theme = struct {
+    // Рамки панелей
+    ActiveBorder   lipgloss.Style
+    InactiveBorder lipgloss.Style
+
+    // Method badges в sidebar
+    MethodGET    lipgloss.Style
+    MethodPOST   lipgloss.Style
+    MethodPUT    lipgloss.Style
+    MethodPATCH  lipgloss.Style
+    MethodDELETE lipgloss.Style
+
+    // HTTP status codes
+    Status2xx lipgloss.Style
+    Status3xx lipgloss.Style
+    Status4xx lipgloss.Style
+    Status5xx lipgloss.Style
+
+    // Общие
+    Bold        lipgloss.Style
+    Muted       lipgloss.Style
+    Error       lipgloss.Style
+    Highlight   lipgloss.Style
+    TabActive   lipgloss.Style
+    TabInactive lipgloss.Style
+}{
+    ActiveBorder:   lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("62")),
+    InactiveBorder: lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("238")),
+
+    MethodGET:    lipgloss.NewStyle().Foreground(lipgloss.Color("42")).Bold(true),
+    MethodPOST:   lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true),
+    MethodPUT:    lipgloss.NewStyle().Foreground(lipgloss.Color("33")).Bold(true),
+    MethodPATCH:  lipgloss.NewStyle().Foreground(lipgloss.Color("141")).Bold(true),
+    MethodDELETE: lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true),
+
+    Status2xx: lipgloss.NewStyle().Foreground(lipgloss.Color("42")).Bold(true),
+    Status3xx: lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true),
+    Status4xx: lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true),
+    Status5xx: lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true),
+
+    Bold:        lipgloss.NewStyle().Bold(true),
+    Muted:       lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
+    Error:       lipgloss.NewStyle().Foreground(lipgloss.Color("196")),
+    Highlight:   lipgloss.NewStyle().Foreground(lipgloss.Color("62")),
+    TabActive:   lipgloss.NewStyle().Foreground(lipgloss.Color("62")).Bold(true).Underline(true),
+    TabInactive: lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
+}
+
+// MethodStyle возвращает стиль для конкретного HTTP метода.
+func MethodStyle(method string) lipgloss.Style {
+    switch method {
+    case "GET":
+        return Theme.MethodGET
+    case "POST":
+        return Theme.MethodPOST
+    case "PUT":
+        return Theme.MethodPUT
+    case "PATCH":
+        return Theme.MethodPATCH
+    case "DELETE":
+        return Theme.MethodDELETE
+    default:
+        return Theme.Bold
+    }
+}
+
+// StatusStyle возвращает стиль для HTTP status code.
+func StatusStyle(code int) lipgloss.Style {
+    switch {
+    case code >= 200 && code < 300:
+        return Theme.Status2xx
+    case code >= 300 && code < 400:
+        return Theme.Status3xx
+    case code >= 400 && code < 500:
+        return Theme.Status4xx
+    case code >= 500:
+        return Theme.Status5xx
+    default:
+        return Theme.Muted
+    }
+}

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -2,6 +2,17 @@ package ui
 
 import "github.com/charmbracelet/lipgloss"
 
+const (
+    colorGreen     = lipgloss.Color("42")
+    colorOrange    = lipgloss.Color("214")
+    colorBlue      = lipgloss.Color("33")
+    colorPurple    = lipgloss.Color("141")
+    colorRed       = lipgloss.Color("196")
+    colorHighlight = lipgloss.Color("62")
+    colorMuted     = lipgloss.Color("240")
+    colorBorder    = lipgloss.Color("238")
+)
+
 var Theme = struct {
     // Рамки панелей
     ActiveBorder   lipgloss.Style
@@ -28,26 +39,26 @@ var Theme = struct {
     TabActive   lipgloss.Style
     TabInactive lipgloss.Style
 }{
-    ActiveBorder:   lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("62")),
-    InactiveBorder: lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("238")),
+    ActiveBorder:   lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(colorHighlight),
+    InactiveBorder: lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(colorBorder),
 
-    MethodGET:    lipgloss.NewStyle().Foreground(lipgloss.Color("42")).Bold(true),
-    MethodPOST:   lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true),
-    MethodPUT:    lipgloss.NewStyle().Foreground(lipgloss.Color("33")).Bold(true),
-    MethodPATCH:  lipgloss.NewStyle().Foreground(lipgloss.Color("141")).Bold(true),
-    MethodDELETE: lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true),
+    MethodGET:    lipgloss.NewStyle().Foreground(colorGreen).Bold(true),
+    MethodPOST:   lipgloss.NewStyle().Foreground(colorOrange).Bold(true),
+    MethodPUT:    lipgloss.NewStyle().Foreground(colorBlue).Bold(true),
+    MethodPATCH:  lipgloss.NewStyle().Foreground(colorPurple).Bold(true),
+    MethodDELETE: lipgloss.NewStyle().Foreground(colorRed).Bold(true),
 
-    Status2xx: lipgloss.NewStyle().Foreground(lipgloss.Color("42")).Bold(true),
-    Status3xx: lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true),
-    Status4xx: lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true),
-    Status5xx: lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true),
+    Status2xx: lipgloss.NewStyle().Foreground(colorGreen).Bold(true),
+    Status3xx: lipgloss.NewStyle().Foreground(colorOrange).Bold(true),
+    Status4xx: lipgloss.NewStyle().Foreground(colorRed).Bold(true),
+    Status5xx: lipgloss.NewStyle().Foreground(colorRed).Bold(true),
 
     Bold:        lipgloss.NewStyle().Bold(true),
-    Muted:       lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
-    Error:       lipgloss.NewStyle().Foreground(lipgloss.Color("196")),
-    Highlight:   lipgloss.NewStyle().Foreground(lipgloss.Color("62")),
-    TabActive:   lipgloss.NewStyle().Foreground(lipgloss.Color("62")).Bold(true).Underline(true),
-    TabInactive: lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
+    Muted:       lipgloss.NewStyle().Foreground(colorMuted),
+    Error:       lipgloss.NewStyle().Foreground(colorRed),
+    Highlight:   lipgloss.NewStyle().Foreground(colorHighlight),
+    TabActive:   lipgloss.NewStyle().Foreground(colorHighlight).Bold(true).Underline(true),
+    TabInactive: lipgloss.NewStyle().Foreground(colorMuted),
 }
 
 // MethodStyle возвращает стиль для конкретного HTTP метода.


### PR DESCRIPTION
Реализован фундамент TUI-приложения (Task 05).

В этом PR:

- Добавлен единый каталог стилей `ui.Theme` (рамки, цвета для HTTP-методов и статусов), компоненты больше не задают цвета напрямую.
- Реализован layout-движок (`LayoutMode`, `ComputeLayout`, `ComputePanelDimensions`, `RenderLayout`), который переключает Wide/Narrow/Minimal раскладки в зависимости от ширины терминала.
- Имплементирована корневая модель `App` c тремя панелями (sidebar, editor, response), системой фокуса (`Tab` / `Shift+Tab`), help overlay (`?`) и глобальными клавишами выхода (`q` / `Ctrl+C`).
- View собирает три панели с рамками и пересчитывает размеры при `tea.WindowSizeMsg`.

Содержимое панелей и HTTP-логика пока заглушены; цель этого PR — только каркас интерфейса и маршрутизация событий.

- Реализован help overlay с горячими клавишами (Task 09).
- Добавлен `ui.HelpModel` и `RenderHelpOverlay`, использующие lipgloss для центрирования и затемнения фона.
- Интегрирован help‑экран в `App` через поле `showHelp` и модель `help`.
- Глобальный хоткей `?` открывает/закрывает help, `esc` закрывает help при активном overlay.
- Пока help открыт, все остальные клавиши перехватываются и не доходят до панелей.