### PR TITLE
Task 10: Implement demo requests on first run and improve response view

### DIFF
--- a/.continue/agents/new-config.yaml
+++ b/.continue/agents/new-config.yaml
@@ -1,0 +1,23 @@
+# This is an example configuration file
+# To learn more, see the full config.yaml reference: https://docs.continue.dev/reference
+
+name: Example Config
+version: 1.0.0
+schema: v1
+
+# Define which models can be used
+# https://docs.continue.dev/customization/models
+models:
+  - name: my gpt-5
+    provider: openai
+    model: gpt-5
+    apiKey: YOUR_OPENAI_API_KEY_HERE
+  - uses: ollama/qwen2.5-coder-7b
+  - uses: anthropic/claude-4-sonnet
+    with:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+# MCP Servers that Continue can access
+# https://docs.continue.dev/customization/mcp-tools
+mcpServers:
+  - uses: anthropic/memory-mcp

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.3.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -1,26 +1,26 @@
 package app
 
 import (
-    "time"
+	"time"
 
-    tea "github.com/charmbracelet/bubbletea"
+	tea "github.com/charmbracelet/bubbletea"
 
-    "htui/internal/httpclient"
-    "htui/internal/requesteditor"
-    "htui/internal/responsedisplay"
-    "htui/internal/sidebar"
-    "htui/internal/store"
-    "htui/internal/types"
-    "htui/internal/ui"
+	"htui/internal/httpclient"
+	"htui/internal/requesteditor"
+	"htui/internal/responsedisplay"
+	"htui/internal/sidebar"
+	"htui/internal/store"
+	"htui/internal/types"
+	"htui/internal/ui"
 )
 
 // FocusedPanel определяет, какая панель сейчас активна.
 type FocusedPanel int
 
 const (
-    PanelSidebar FocusedPanel = iota
-    PanelEditor
-    PanelResponse
+	PanelSidebar FocusedPanel = iota
+	PanelEditor
+	PanelResponse
 )
 
 // Сообщения от дочерних компонентов вверх.
@@ -34,99 +34,99 @@ type ResponseCompleteMsg struct{ Data types.ResponseData }
 
 // App — корневая модель приложения.
 type App struct {
-    // Глобальные хоткеи
-    keys KeyMap
+	// Глобальные хоткеи
+	keys KeyMap
 
-    // Подмодели
-    sidebar  sidebar.Model
-    editor   requesteditor.Model
-    response responsedisplay.Model
-    help     ui.HelpModel
+	// Подмодели
+	sidebar  sidebar.Model
+	editor   requesteditor.Model
+	response responsedisplay.Model
+	help     ui.HelpModel
 
-    // Состояние UI
-    focus      FocusedPanel
-    loading    bool
-    showHelp   bool
-    width      int
-    height     int
-    layoutMode ui.LayoutMode
+	// Состояние UI
+	focus      FocusedPanel
+	loading    bool
+	showHelp   bool
+	width      int
+	height     int
+	layoutMode ui.LayoutMode
 
-    // Хранилище и HTTP-клиент
-    store  store.Store
-    client *httpclient.Client
-    nextMethodIdx int
+	// Хранилище и HTTP-клиент
+	store         store.Store
+	client        *httpclient.Client
+	nextMethodIdx int
 }
 
 // New инициализирует приложение:
-// создаёт store, сидирует демо если первый запуск, загружает запросы.
+// создаёт store, сидирует демо если первый запуск, загружает запросы
 func New() (App, error) {
-    s, err := store.New()
-    if err != nil {
-        return App{}, err
-    }
+	s, err := store.New()
+	if err != nil {
+		return App{}, err
+	}
 
-    firstRun, err := s.IsFirstRun()
-    if err != nil {
-        return App{}, err
-    }
-    if firstRun {
-        for _, r := range types.DemoRequests() {
-            if err := s.Save(r); err != nil {
-                return App{}, err
-            }
-        }
-        if err := s.MarkSeeded(); err != nil {
-            return App{}, err
-        }
-    }
+	firstRun, err := s.IsFirstRun()
+	if err != nil {
+		return App{}, err
+	}
+	if firstRun {
+		for _, r := range types.DemoRequests() {
+			if err := s.Save(r); err != nil {
+				return App{}, err
+			}
+		}
+		if err := s.MarkSeeded(); err != nil {
+			return App{}, err
+		}
+	}
 
-    requests, err := s.List()
-    if err != nil {
-        return App{}, err
-    }
+	requests, err := s.List()
+	if err != nil {
+		return App{}, err
+	}
 
-    m := App{
-        store:  s,
-        client: httpclient.New(),
-        keys:   DefaultKeyMap, // <-- используем KeyMap из keymap.go
-        focus:  PanelSidebar,
-    }
+	m := App{
+		store:  s,
+		client: httpclient.New(),
+		keys:   DefaultKeyMap, //используем KeyMap из keymap.go
+		focus:  PanelEditor,
+	}
 
-    m.sidebar = sidebar.New(requests)
-    m.editor = requesteditor.New()
-    m.response = responsedisplay.New()
-    // nil — использовать defaultSections() внутри ui.NewHelpModel,
-    // но ты можешь передать сюда и конкретный map, если будешь использовать bindings.
-    m.help = ui.NewHelpModel(nil)
+	m.sidebar = sidebar.New(requests)
+	m.editor = requesteditor.New()
+	m.response = responsedisplay.New()
+	// nil — использовать defaultSections() внутри ui.NewHelpModel,
+	// но можно просто передать сюда и конкретный map, если использовать bindings
+	m.help = ui.NewHelpModel(nil)
 
-    // Автовыбор первого запроса
-    if len(requests) > 0 {
-        m.editor = m.editor.LoadRequest(requests[0])
-        m.sidebar = m.sidebar.SelectFirst()
-    }
+	// Автовыбор первого запроса
+	if len(requests) > 0 {
+		m.editor = m.editor.LoadRequest(requests[0])
+		m.sidebar = m.sidebar.SelectFirst()
+	}
 
-    return m, nil
+	return m, nil
 }
 
 func (m App) Init() tea.Cmd {
-    return nil
+	return nil
 }
 
 // ready возвращает false пока не получены размеры терминала.
 func (m App) ready() bool {
-    return m.width > 0 && m.height > 0
+	return m.width > 0 && m.height > 0
 }
 
 // shiftFocus циклично переключает фокус между панелями.
 func (m App) shiftFocus(delta int) App {
-    panels := []FocusedPanel{PanelSidebar, PanelEditor, PanelResponse}
-    idx := int(m.focus)
-    idx = (idx + delta + len(panels)) % len(panels)
-    m.focus = panels[idx]
-    return m
+	panels := []FocusedPanel{PanelSidebar, PanelEditor, PanelResponse}
+	idx := int(m.focus)
+	idx = (idx + delta + len(panels)) % len(panels)
+	m.focus = panels[idx]
+	return m
 }
 
 // now вынесен сюда, чтобы использовать в update.go
 func now() int64 {
-    return time.Now().UnixNano()
+	return time.Now().UnixNano()
 }

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -123,7 +123,8 @@ func (m App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
     case RequestSavedMsg:
         // после любого Save — перезагружать только сайдбар
         m.sidebar = m.sidebar.Reload(m.store)
-        // не переключаем фокус в редактор, чтобы d/delete/n не прыгали во вторую колонку
+        // Очистить редактор для нового запроса
+        m.editor = m.editor.Clear()
         return m, nil
 
     case RequestDeletedMsg:

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -115,7 +115,7 @@ func (m App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
         }
         m.loading = true
         m.response = m.response.SetLoading(true)
-        return m, sendRequestCmd(m.client, msg.Request)
+        return m, tea.Batch(m.response.SpinnerCmd(), sendRequestCmd(m.client, msg.Request))
 
     case requesteditor.SaveRequestMsg:
         return m, saveRequestCmd(m.store, msg.Request)

--- a/internal/requesteditor/fields.go
+++ b/internal/requesteditor/fields.go
@@ -1,0 +1,228 @@
+package requesteditor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"htui/internal/types"
+	"htui/internal/ui"
+)
+
+// KVTable — редактируемая таблица пар ключ-значение.
+// Используется для Headers, Params и form-urlencoded body.
+type KVTable struct {
+	rows    []kvRow
+	cursor  int  // активная строка
+	editCol int  // 0=key, 1=value
+	editing bool
+	input   textinput.Model // переиспользуется для редактирования любой ячейки
+	width   int
+}
+
+type kvRow struct {
+	key     string
+	value   string
+	enabled bool
+}
+
+// NewKVTable создаёт пустую таблицу с одной пустой строкой.
+func NewKVTable() KVTable {
+	ti := textinput.New()
+	ti.CharLimit = 500
+	return KVTable{
+		rows:  []kvRow{{enabled: true}},
+		input: ti,
+	}
+}
+
+// FromHeaders / FromParams — конверторы из types в KVTable.
+func FromHeaders(headers []types.Header) KVTable {
+	t := NewKVTable()
+	if len(headers) == 0 {
+		return t
+	}
+	t.rows = make([]kvRow, len(headers))
+	for i, h := range headers {
+		t.rows[i] = kvRow{key: h.Key, value: h.Value, enabled: h.Enabled}
+	}
+	return t
+}
+
+func FromParams(params []types.Param) KVTable {
+	t := NewKVTable()
+	if len(params) == 0 {
+		return t
+	}
+	t.rows = make([]kvRow, len(params))
+	for i, p := range params {
+		t.rows[i] = kvRow{key: p.Key, value: p.Value, enabled: p.Enabled}
+	}
+	return t
+}
+
+// ToHeaders / ToParams — конверторы обратно в types.
+func (t KVTable) ToHeaders() []types.Header {
+	var result []types.Header
+	for _, r := range t.rows {
+		if r.key != "" {
+			result = append(result, types.Header{Key: r.key, Value: r.value, Enabled: r.enabled})
+		}
+	}
+	return result
+}
+
+func (t KVTable) ToParams() []types.Param {
+	var result []types.Param
+	for _, r := range t.rows {
+		if r.key != "" {
+			result = append(result, types.Param{Key: r.key, Value: r.value, Enabled: r.enabled})
+		}
+	}
+	return result
+}
+
+func (t KVTable) Update(msg tea.Msg) (KVTable, tea.Cmd) {
+	if t.editing {
+		switch msg := msg.(type) {
+		case tea.KeyMsg:
+			switch msg.String() {
+			case "esc":
+				// Сохранить изменения и выйти из редактирования
+				t = t.commitEdit()
+				t.editing = false
+				return t, nil
+			case "tab", "enter":
+				// Переключить колонку или перейти к следующей строке
+				t = t.commitEdit()
+				if msg.String() == "tab" {
+					t.editCol = (t.editCol + 1) % 2
+					t = t.startEdit()
+				} else {
+					t.editing = false
+				}
+				return t, nil
+			}
+		}
+		var c tea.Cmd
+		t.input, c = t.input.Update(msg)
+		return t, c
+	}
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "up", "k":
+			if t.cursor > 0 {
+				t.cursor--
+			}
+		case "down", "j":
+			if t.cursor < len(t.rows)-1 {
+				t.cursor++
+			}
+		case "enter":
+			t.editCol = 0
+			t = t.startEdit()
+		case "tab":
+			t.editCol = 1
+			t = t.startEdit()
+		case "a":
+			t.rows = append(t.rows, kvRow{enabled: true})
+			t.cursor = len(t.rows) - 1
+		case "delete", "backspace":
+			if len(t.rows) > 1 {
+				t.rows = append(t.rows[:t.cursor], t.rows[t.cursor+1:]...)
+				if t.cursor >= len(t.rows) {
+					t.cursor = len(t.rows) - 1
+				}
+			} else {
+				t.rows[0] = kvRow{enabled: true}
+			}
+		case " ":
+			t.rows[t.cursor].enabled = !t.rows[t.cursor].enabled
+		}
+	}
+	return t, nil
+}
+
+func (t KVTable) View() string {
+	var sb strings.Builder
+
+	// Заголовок таблицы
+	keyW := t.width/2 - 2
+	valW := t.width - keyW - 4
+	header := ui.Theme.Muted.Render(
+		fmt.Sprintf("  %-*s  %-*s", keyW, "Key", valW, "Value"),
+	)
+	sb.WriteString(header + "\n")
+
+	for i, row := range t.rows {
+		prefix := "  "
+		if i == t.cursor {
+			prefix = ui.Theme.Highlight.Render("> ")
+		}
+
+		enabled := ui.Theme.Muted.Render("✓")
+		if !row.enabled {
+			enabled = ui.Theme.Muted.Render("○")
+		}
+
+		var keyStr, valStr string
+		if t.editing && i == t.cursor {
+			if t.editCol == 0 {
+				keyStr = t.input.View()
+				valStr = ui.Theme.Muted.Render(row.value)
+			} else {
+				keyStr = ui.Theme.Muted.Render(row.key)
+				valStr = t.input.View()
+			}
+		} else {
+			keyStr = row.key
+			if keyStr == "" {
+				keyStr = ui.Theme.Muted.Render("(key)")
+			}
+			valStr = row.value
+			if valStr == "" {
+				valStr = ui.Theme.Muted.Render("(value)")
+			}
+		}
+
+		line := fmt.Sprintf("%s%s %-*s  %-*s", prefix, enabled, keyW, keyStr, valW, valStr)
+		sb.WriteString(line + "\n")
+	}
+
+	sb.WriteString(ui.Theme.Muted.Render("\n  [a] add  [del] remove  [space] toggle  [enter] edit"))
+	return sb.String()
+}
+
+func (t KVTable) SetWidth(w int) KVTable {
+	t.width = w
+	t.input.Width = w/2 - 4
+	return t
+}
+
+func (t *KVTable) startEdit() KVTable {
+	t.editing = true
+	var val string
+	if t.editCol == 0 {
+		val = t.rows[t.cursor].key
+	} else {
+		val = t.rows[t.cursor].value
+	}
+	t.input.SetValue(val)
+	t.input.Focus()
+	t.input.CursorEnd()
+	return *t
+}
+
+func (t *KVTable) commitEdit() KVTable {
+	val := t.input.Value()
+	if t.editCol == 0 {
+		t.rows[t.cursor].key = val
+	} else {
+		t.rows[t.cursor].value = val
+	}
+	t.input.Blur()
+	return *t
+}

--- a/internal/requesteditor/fields.go
+++ b/internal/requesteditor/fields.go
@@ -103,6 +103,19 @@ func (t KVTable) Update(msg tea.Msg) (KVTable, tea.Cmd) {
 					t.editing = false
 				}
 				return t, nil
+			case "left", "right":
+				// Переместиться на соседнюю колонку
+				t = t.commitEdit()
+				if msg.String() == "right" && t.editCol == 0 {
+					t.editCol = 1
+					t = t.startEdit()
+				} else if msg.String() == "left" && t.editCol == 1 {
+					t.editCol = 0
+					t = t.startEdit()
+				} else {
+					t.editing = false
+				}
+				return t, nil
 			}
 		}
 		var c tea.Cmd
@@ -121,6 +134,12 @@ func (t KVTable) Update(msg tea.Msg) (KVTable, tea.Cmd) {
 			if t.cursor < len(t.rows)-1 {
 				t.cursor++
 			}
+		case "left":
+			t.editCol = 0
+			t = t.startEdit()
+		case "right":
+			t.editCol = 1
+			t = t.startEdit()
 		case "enter":
 			t.editCol = 0
 			t = t.startEdit()
@@ -148,6 +167,8 @@ func (t KVTable) Update(msg tea.Msg) (KVTable, tea.Cmd) {
 
 func (t KVTable) View() string {
 	var sb strings.Builder
+
+	sb.WriteString("\n")
 
 	// Заголовок таблицы
 	keyW := t.width/2 - 2
@@ -192,7 +213,7 @@ func (t KVTable) View() string {
 		sb.WriteString(line + "\n")
 	}
 
-	sb.WriteString(ui.Theme.Muted.Render("\n  [a] add  [del] remove  [space] toggle  [enter] edit"))
+	sb.WriteString(ui.Theme.Muted.Render("\n  [a] add  [del] remove  [space] toggle  [</>] switch  [enter] edit"))
 	return sb.String()
 }
 

--- a/internal/requesteditor/model.go
+++ b/internal/requesteditor/model.go
@@ -1,23 +1,23 @@
 package requesteditor
 
 import (
-	"strings"
+    "strings"
 
-	"github.com/charmbracelet/bubbles/textarea"
-	"github.com/charmbracelet/bubbles/textinput"
-	tea "github.com/charmbracelet/bubbletea"
-	"htui/internal/types"
-	"htui/internal/ui"
+    "github.com/charmbracelet/bubbles/textarea"
+    "github.com/charmbracelet/bubbles/textinput"
+    tea "github.com/charmbracelet/bubbletea"
+    "htui/internal/types"
+    "htui/internal/ui"
 )
 
 // EditorTab — вкладка в редакторе запроса.
 type EditorTab int
 
 const (
-	TabBody    EditorTab = iota
-	TabHeaders
-	TabParams
-	TabAuth
+    TabBody EditorTab = iota
+    TabHeaders
+    TabParams
+    TabAuth
 )
 
 var tabNames = []string{"Body", "Headers", "Params", "Auth"}
@@ -26,9 +26,9 @@ var tabNames = []string{"Body", "Headers", "Params", "Auth"}
 type FocusField int
 
 const (
-	FieldMethod  FocusField = iota
-	FieldURL
-	FieldTabContent // всё что ниже tab bar
+    FieldMethod FocusField = iota
+    FieldURL
+    FieldTabContent // всё что ниже tab bar
 )
 
 // --- Сообщения вверх в App ---
@@ -39,474 +39,465 @@ type SaveRequestMsg struct{ Request types.SavedRequest }
 // --- Модель ---
 
 type Model struct {
-	current  types.SavedRequest
-	dirty    bool
+    current types.SavedRequest
+    dirty   bool
 
-	// Поля
-	urlInput    textinput.Model
-	bodyInput   textarea.Model
-	headerTable KVTable
-	paramTable  KVTable
-	bodyModeIdx int // индекс в []BodyMode
+    // Поля
+    urlInput    textinput.Model
+    bodyInput   textarea.Model
+    headerTable KVTable
+    paramTable  KVTable
+    bodyModeIdx int // индекс в []BodyMode
 
-	// Auth
-	authTypeIdx  int // 0=none, 1=bearer
-	tokenInput   textinput.Model
-	tokenVisible bool
+    // Auth
+    authTypeIdx  int // 0=none, 1=bearer
+    tokenInput   textinput.Model
+    tokenVisible bool
 
-	// UI-состояние
-	activeTab      EditorTab
-	focusField     FocusField
-	methodIdx      int // индекс в types.HTTPMethods
-	focused        bool
-	width          int
-	height         int
-	validationErrs []string // показываются под URL при ctrl+enter с ошибкой
+    // UI-состояние
+    activeTab      EditorTab
+    focusField     FocusField
+    methodIdx      int // индекс в types.HTTPMethods
+    focused        bool
+    width          int
+    height         int
+    validationErrs []string // показываются под URL при ошибке
 }
 
 var bodyModes = []types.BodyMode{
-	types.BodyModeNone,
-	types.BodyModeRawText,
-	types.BodyModeJSON,
-	types.BodyModeForm,
+    types.BodyModeNone,
+    types.BodyModeRawText,
+    types.BodyModeJSON,
+    types.BodyModeForm,
 }
 
 var bodyModeLabels = []string{"none", "raw", "json", "form"}
 
 // New создаёт пустой редактор.
 func New() Model {
-	url := textinput.New()
-	url.Placeholder = "https://api.example.com/endpoint"
-	url.CharLimit = 2000
-	url.Focus()
+    url := textinput.New()
+    url.Placeholder = "https://api.example.com/endpoint"
+    url.CharLimit = 2000
+    url.Focus()
 
-	body := textarea.New()
-	body.Placeholder = "Request body..."
-	body.CharLimit = 0 // без ограничений
-	body.SetHeight(8)
+    body := textarea.New()
+    body.Placeholder = "Request body..."
+    body.CharLimit = 0 // без ограничений
+    body.SetHeight(8)
 
-	token := textinput.New()
-	token.Placeholder = "Enter bearer token..."
-	token.EchoMode = textinput.EchoPassword
-	token.CharLimit = 500
+    token := textinput.New()
+    token.Placeholder = "Enter bearer token..."
+    token.EchoMode = textinput.EchoPassword
+    token.CharLimit = 500
 
-	return Model{
-		current:     types.NewSavedRequest(),
-		urlInput:    url,
-		bodyInput:   body,
-		headerTable: NewKVTable(),
-		paramTable:  NewKVTable(),
-		tokenInput:  token,
-		focusField:  FieldURL,
-	}
+    return Model{
+        current:     types.NewSavedRequest(),
+        urlInput:    url,
+        bodyInput:   body,
+        headerTable: NewKVTable(),
+        paramTable:  NewKVTable(),
+        tokenInput:  token,
+        focusField:  FieldURL,
+    }
 }
 
 // LoadRequest загружает существующий запрос в редактор.
 func (m Model) LoadRequest(r types.SavedRequest) Model {
-	m.current     = r
-	m.dirty       = false
+    m.current = r
+    m.dirty = false
 
-	// URL
-	m.urlInput.SetValue(r.URL)
+    // URL
+    m.urlInput.SetValue(r.URL)
 
-	// Method
-	m.methodIdx = 0
-	for i, method := range types.HTTPMethods {
-		if method == r.Method {
-			m.methodIdx = i
-			break
-		}
-	}
+    // Method
+    m.methodIdx = 0
+    for i, method := range types.HTTPMethods {
+        if method == r.Method {
+            m.methodIdx = i
+            break
+        }
+    }
 
-	// Body mode
-	m.bodyModeIdx = 0
-	for i, bm := range bodyModes {
-		if bm == r.BodyMode {
-			m.bodyModeIdx = i
-			break
-		}
-	}
-	m.bodyInput.SetValue(r.Body)
+    // Body mode
+    m.bodyModeIdx = 0
+    for i, bm := range bodyModes {
+        if bm == r.BodyMode {
+            m.bodyModeIdx = i
+            break
+        }
+    }
+    m.bodyInput.SetValue(r.Body)
 
-	// Headers / Params
-	m.headerTable = FromHeaders(r.Headers)
-	m.paramTable  = FromParams(r.Params)
+    // Headers / Params
+    m.headerTable = FromHeaders(r.Headers)
+    m.paramTable = FromParams(r.Params)
 
-	// Auth
-	if r.Auth.Type == types.AuthBearer {
-		m.authTypeIdx = 1
-	} else {
-		m.authTypeIdx = 0
-	}
-	m.tokenInput.SetValue(r.Auth.Token)
-	m.tokenVisible = r.Auth.TokenVisible
+    // Auth
+    if r.Auth.Type == types.AuthBearer {
+        m.authTypeIdx = 1
+    } else {
+        m.authTypeIdx = 0
+    }
+    m.tokenInput.SetValue(r.Auth.Token)
+    m.tokenVisible = r.Auth.TokenVisible
 
-	m.validationErrs = nil
-	return m
+    m.validationErrs = nil
+    return m
 }
 
 // Clear сбрасывает редактор в пустое состояние.
 func (m Model) Clear() Model {
-	return New()
+    return New()
 }
 
 // CurrentID возвращает ID текущего запроса (для сравнения при удалении).
 func (m Model) CurrentID() string {
-	return m.current.ID
+    return m.current.ID
 }
 
 // BuildRequest собирает types.SavedRequest из текущего состояния полей.
 func (m Model) BuildRequest() types.SavedRequest {
-	r := m.current
-	r.Method   = types.HTTPMethods[m.methodIdx]
-	r.URL      = m.urlInput.Value()
-	r.BodyMode = bodyModes[m.bodyModeIdx]
-	r.Body     = m.bodyInput.Value()
-	r.Headers  = m.headerTable.ToHeaders()
-	r.Params   = m.paramTable.ToParams()
+    r := m.current
+    r.Method = types.HTTPMethods[m.methodIdx]
+    r.URL = m.urlInput.Value()
+    r.BodyMode = bodyModes[m.bodyModeIdx]
+    r.Body = m.bodyInput.Value()
+    r.Headers = m.headerTable.ToHeaders()
+    r.Params = m.paramTable.ToParams()
 
-	if m.authTypeIdx == 1 {
-		r.Auth = types.AuthConfig{
-			Type:         types.AuthBearer,
-			Token:        m.tokenInput.Value(),
-			TokenVisible: m.tokenVisible,
-		}
-	} else {
-		r.Auth = types.AuthConfig{Type: types.AuthNone}
-	}
+    if m.authTypeIdx == 1 {
+        r.Auth = types.AuthConfig{
+            Type:         types.AuthBearer,
+            Token:        m.tokenInput.Value(),
+            TokenVisible: m.tokenVisible,
+        }
+    } else {
+        r.Auth = types.AuthConfig{Type: types.AuthNone}
+    }
 
-	return r
+    return r
 }
 
 func (m Model) Init() tea.Cmd { return nil }
 
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch msg.String() {
-		case "ctrl+enter":
-			req := m.BuildRequest()
-			result := Validate(req)
-			if !result.Valid {
-				m.validationErrs = result.Errors
-				return m, nil
-			}
-			m.validationErrs = nil
-			return m, func() tea.Msg { return SendRequestMsg{Request: req} }
+    switch msg := msg.(type) {
+    case tea.KeyMsg:
+        switch msg.String() {
+        // Отправка по Enter
+        case "enter":
+            req := m.BuildRequest()
+            result := Validate(req)
+            if !result.Valid {
+                m.validationErrs = result.Errors
+                return m, nil
+            }
+            m.validationErrs = nil
+            return m, func() tea.Msg { return SendRequestMsg{Request: req} }
 
-		case "ctrl+s":
-			req := m.BuildRequest()
-			m.dirty = false
-			return m, func() tea.Msg { return SaveRequestMsg{Request: req} }
+        // Сохранение всегда как новый
+        case "ctrl+s":
+            req := m.BuildRequest()
+            // сбрасываем ID, чтобы storage создал новый запрос
+            req.ID = ""
+            m.dirty = false
+            return m, func() tea.Msg { return SaveRequestMsg{Request: req} }
 
-		case "up":
-			switch m.focusField {
-			case FieldURL:
-				m.focusField = FieldMethod
-				return m, nil
-			case FieldTabContent:
-				// Можешь переключаться между вкладками вверх/вниз тоже
-				m.activeTab = EditorTab((int(m.activeTab)-1+len(tabNames)) % len(tabNames))
-				m = m.focusTabContent()
-				return m, nil
-			}
-		case "down":
-			switch m.focusField {
-			case FieldMethod:
-				m.focusField = FieldURL
-				m.urlInput.Focus()
-				return m, nil
-			case FieldURL:
-				m.urlInput.Blur()
-				m.focusField = FieldTabContent
-				m = m.focusTabContent()
-				return m, nil
-			case FieldTabContent:
-				// Переключение между вкладками вниз
-				m.activeTab = EditorTab((int(m.activeTab)+1) % len(tabNames))
-				m = m.focusTabContent()
-				return m, nil
-			}
-		case "left", "right":
-			if m.focusField == FieldMethod {
-				delta := 1
-				if msg.String() == "left" {
-					delta = -1
-				}
-				m.methodIdx = (m.methodIdx + delta + len(types.HTTPMethods)) % len(types.HTTPMethods)
-				m.dirty = true
-				return m, nil
-			}
-			// Left/Right на Body вкладке работают для Mode selector
-			if m.focusField == FieldTabContent && m.activeTab == TabBody {
-				switch msg.String() {
-				case "left":
-					if m.bodyModeIdx > 0 {
-						m.bodyModeIdx--
-						m.dirty = true
-						m = m.focusTabContent()
-					}
-					return m, nil
-				case "right":
-					if m.bodyModeIdx < len(bodyModes)-1 {
-						m.bodyModeIdx++
-						m.dirty = true
-						m = m.focusTabContent()
-					}
-					return m, nil
-				}
-			}
+        case "up":
+            switch m.focusField {
+            case FieldURL:
+                m.focusField = FieldMethod
+                return m, nil
+            case FieldTabContent:
+                m.activeTab = EditorTab((int(m.activeTab) - 1 + len(tabNames)) % len(tabNames))
+                m = m.focusTabContent()
+                return m, nil
+            }
+        case "down":
+            switch m.focusField {
+            case FieldMethod:
+                m.focusField = FieldURL
+                m.urlInput.Focus()
+                return m, nil
+            case FieldURL:
+                m.urlInput.Blur()
+                m.focusField = FieldTabContent
+                m = m.focusTabContent()
+                return m, nil
+            case FieldTabContent:
+                m.activeTab = EditorTab((int(m.activeTab) + 1) % len(tabNames))
+                m = m.focusTabContent()
+                return m, nil
+            }
+        case "left", "right":
+            if m.focusField == FieldMethod {
+                delta := 1
+                if msg.String() == "left" {
+                    delta = -1
+                }
+                m.methodIdx = (m.methodIdx + delta + len(types.HTTPMethods)) % len(types.HTTPMethods)
+                m.dirty = true
+                return m, nil
+            }
+            if m.focusField == FieldTabContent && m.activeTab == TabBody {
+                switch msg.String() {
+                case "left":
+                    if m.bodyModeIdx > 0 {
+                        m.bodyModeIdx--
+                        m.dirty = true
+                        m = m.focusTabContent()
+                    }
+                    return m, nil
+                case "right":
+                    if m.bodyModeIdx < len(bodyModes)-1 {
+                        m.bodyModeIdx++
+                        m.dirty = true
+                        m = m.focusTabContent()
+                    }
+                    return m, nil
+                }
+            }
+        case "1", "2", "3", "4", "5":
+            idx := int(msg.String()[0] - '1')
+            if idx < len(types.HTTPMethods) {
+                m.methodIdx = idx
+                m.dirty = true
+            }
+            return m, nil
+        }
+    }
 
-		case "1", "2", "3", "4", "5":
-			// Быстрый выбор метода цифрами
-			idx := int(msg.String()[0]-'1')
-			if idx < len(types.HTTPMethods) {
-				m.methodIdx = idx
-				m.dirty = true
-			}
-			return m, nil
-		}
-	}
-
-	// Роутинг к активному полю
-	return m.routeToActiveField(msg)
+    return m.routeToActiveField(msg)
 }
 
 // routeToActiveField передаёт сообщение в текущий активный subcomponent.
 func (m Model) routeToActiveField(msg tea.Msg) (Model, tea.Cmd) {
-	var cmd tea.Cmd
+    var cmd tea.Cmd
 
-	switch m.focusField {
-	case FieldURL:
-		m.urlInput, cmd = m.urlInput.Update(msg)
-		m.dirty = true
+    switch m.focusField {
+    case FieldURL:
+        m.urlInput, cmd = m.urlInput.Update(msg)
+        m.dirty = true
 
-	case FieldTabContent:
-		switch m.activeTab {
-		case TabBody:
-			if msg, ok := msg.(tea.KeyMsg); ok {
-				switch msg.String() {
-				case "down":
-					// Переход из Mode selector на editor если режим не none
-					if bodyModes[m.bodyModeIdx] != types.BodyModeNone {
-						if bodyModes[m.bodyModeIdx] == types.BodyModeJSON ||
-							bodyModes[m.bodyModeIdx] == types.BodyModeRawText {
-							m.bodyInput.Focus()
-						} else if bodyModes[m.bodyModeIdx] == types.BodyModeForm {
-							// Фокус на таблицу параметров
-						}
-					}
-					return m, nil
-				}
-			}
-			if bodyModes[m.bodyModeIdx] == types.BodyModeJSON ||
-				bodyModes[m.bodyModeIdx] == types.BodyModeRawText {
-				m.bodyInput, cmd = m.bodyInput.Update(msg)
-				m.dirty = true
-			} else if bodyModes[m.bodyModeIdx] == types.BodyModeForm {
-				m.paramTable, cmd = m.paramTable.Update(msg)
-				m.dirty = true
-			}
+    case FieldTabContent:
+        switch m.activeTab {
+        case TabBody:
+            if msg, ok := msg.(tea.KeyMsg); ok {
+                switch msg.String() {
+                case "down":
+                    if bodyModes[m.bodyModeIdx] != types.BodyModeNone {
+                        if bodyModes[m.bodyModeIdx] == types.BodyModeJSON ||
+                            bodyModes[m.bodyModeIdx] == types.BodyModeRawText {
+                            m.bodyInput.Focus()
+                        } else if bodyModes[m.bodyModeIdx] == types.BodyModeForm {
+                            // Фокус на таблицу параметров
+                        }
+                    }
+                    return m, nil
+                }
+            }
+            if bodyModes[m.bodyModeIdx] == types.BodyModeJSON ||
+                bodyModes[m.bodyModeIdx] == types.BodyModeRawText {
+                m.bodyInput, cmd = m.bodyInput.Update(msg)
+                m.dirty = true
+            } else if bodyModes[m.bodyModeIdx] == types.BodyModeForm {
+                m.paramTable, cmd = m.paramTable.Update(msg)
+                m.dirty = true
+            }
 
-		case TabHeaders:
-			m.headerTable, cmd = m.headerTable.Update(msg)
-			m.dirty = true
+        case TabHeaders:
+            m.headerTable, cmd = m.headerTable.Update(msg)
+            m.dirty = true
 
-		case TabParams:
-			m.paramTable, cmd = m.paramTable.Update(msg)
-			m.dirty = true
+        case TabParams:
+            m.paramTable, cmd = m.paramTable.Update(msg)
+            m.dirty = true
 
-		case TabAuth:
-			m = m.updateAuthTab(msg)
-		}
-	}
-	return m, cmd
+        case TabAuth:
+            m = m.updateAuthTab(msg)
+        }
+    }
+    return m, cmd
 }
 
 func (m Model) updateAuthTab(msg tea.Msg) Model {
-	var cmd tea.Cmd
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch msg.String() {
-		case "left", "right":
-			m.authTypeIdx = (m.authTypeIdx + 1) % 2
-			if m.authTypeIdx == 1 {
-				m.tokenInput.Focus()
-			} else {
-				m.tokenInput.Blur()
-			}
-			m.dirty = true
-			return m
-		case "ctrl+h": // show/hide token
-			m.tokenVisible = !m.tokenVisible
-			if m.tokenVisible {
-				m.tokenInput.EchoMode = textinput.EchoNormal
-			} else {
-				m.tokenInput.EchoMode = textinput.EchoPassword
-			}
-			return m
-		}
-	}
-	if m.authTypeIdx == 1 {
-		m.tokenInput, cmd = m.tokenInput.Update(msg)
-		_ = cmd
-		m.dirty = true
-	}
-	return m
+    var cmd tea.Cmd
+    switch msg := msg.(type) {
+    case tea.KeyMsg:
+        switch msg.String() {
+        case "left", "right":
+            m.authTypeIdx = (m.authTypeIdx + 1) % 2
+            if m.authTypeIdx == 1 {
+                m.tokenInput.Focus()
+            } else {
+                m.tokenInput.Blur()
+            }
+            m.dirty = true
+            return m
+        case "ctrl+h":
+            m.tokenVisible = !m.tokenVisible
+            if m.tokenVisible {
+                m.tokenInput.EchoMode = textinput.EchoNormal
+            } else {
+                m.tokenInput.EchoMode = textinput.EchoPassword
+            }
+            return m
+        }
+    }
+    if m.authTypeIdx == 1 {
+        m.tokenInput, cmd = m.tokenInput.Update(msg)
+        _ = cmd
+        m.dirty = true
+    }
+    return m
 }
 
 func (m Model) focusTabContent() Model {
-	switch m.activeTab {
-	case TabBody:
-		if bodyModes[m.bodyModeIdx] != types.BodyModeNone {
-			m.bodyInput.Focus()
-		}
-	case TabAuth:
-		if m.authTypeIdx == 1 {
-			m.tokenInput.Focus()
-		}
-	}
-	return m
+    switch m.activeTab {
+    case TabBody:
+        if bodyModes[m.bodyModeIdx] != types.BodyModeNone {
+            m.bodyInput.Focus()
+        }
+    case TabAuth:
+        if m.authTypeIdx == 1 {
+            m.tokenInput.Focus()
+        }
+    }
+    return m
 }
 
 func (m Model) View() string {
-	if m.width == 0 {
-		return ""
-	}
+    if m.width == 0 {
+        return ""
+    }
 
-	var sb strings.Builder
+    var sb strings.Builder
 
-	// --- Строка метода + URL ---
-	methodLine := m.renderMethodSelector()
-	sb.WriteString(methodLine + "\n")
+    methodLine := m.renderMethodSelector()
+    sb.WriteString(methodLine + "\n")
 
-	urlLine := m.renderURLField()
-	sb.WriteString(urlLine + "\n")
+    urlLine := m.renderURLField()
+    sb.WriteString(urlLine + "\n")
 
-	// Ошибки валидации
-	if len(m.validationErrs) > 0 {
-		for _, e := range m.validationErrs {
-			sb.WriteString(ui.Theme.Error.Render("  ✗ "+e) + "\n")
-		}
-	}
+    if len(m.validationErrs) > 0 {
+        for _, e := range m.validationErrs {
+            sb.WriteString(ui.Theme.Error.Render("  ✗ "+e) + "\n")
+        }
+    }
 
-	sb.WriteString("\n")
+    sb.WriteString("\n")
 
-	// --- Tab bar ---
-	sb.WriteString(m.renderTabBar() + "\n\n")
+    sb.WriteString(m.renderTabBar() + "\n\n")
 
-	// --- Содержимое вкладки ---
-	sb.WriteString(m.renderTabContent())
+    sb.WriteString(m.renderTabContent())
 
-	// --- Подсказка ---
-	hint := ui.Theme.Muted.Render("  ctrl+enter send  ctrl+s save")
-	if m.dirty {
-		hint = ui.Theme.Muted.Render("  ctrl+enter send  ctrl+s save  ") +
-			ui.Theme.Error.Render("● unsaved")
-	}
-	sb.WriteString("\n" + hint)
+    hint := ui.Theme.Muted.Render("  enter send  ctrl+s save as new")
+    if m.dirty {
+        hint = ui.Theme.Muted.Render("  enter send  ctrl+s save as new  ") +
+            ui.Theme.Error.Render("● unsaved")
+    }
+    sb.WriteString("\n" + hint)
 
-	return sb.String()
+    return sb.String()
 }
 
 func (m Model) renderMethodSelector() string {
-	var parts []string
-	for i, method := range types.HTTPMethods {
-		style := ui.Theme.Muted
-		if i == m.methodIdx {
-			style = ui.MethodStyle(method).Bold(true)
-		}
-		parts = append(parts, style.Render("["+method+"]"))
-	}
-	return "  " + strings.Join(parts, " ")
+    var parts []string
+    for i, method := range types.HTTPMethods {
+        style := ui.Theme.Muted
+        if i == m.methodIdx {
+            style = ui.MethodStyle(method).Bold(true)
+        }
+        parts = append(parts, style.Render("["+method+"]"))
+    }
+    return "  " + strings.Join(parts, " ")
 }
 
 func (m Model) renderURLField() string {
-	label := ui.Theme.Muted.Render("  URL: ")
-	return label + m.urlInput.View()
+    label := ui.Theme.Muted.Render("  URL: ")
+    return label + m.urlInput.View()
 }
 
 func (m Model) renderTabBar() string {
-	var parts []string
-	for i, name := range tabNames {
-		if EditorTab(i) == m.activeTab {
-			parts = append(parts, ui.Theme.TabActive.Render(name))
-		} else {
-			parts = append(parts, ui.Theme.TabInactive.Render(name))
-		}
-	}
-	return "  " + strings.Join(parts, "  ")
+    var parts []string
+    for i, name := range tabNames {
+        if EditorTab(i) == m.activeTab {
+            parts = append(parts, ui.Theme.TabActive.Render(name))
+        } else {
+            parts = append(parts, ui.Theme.TabInactive.Render(name))
+        }
+    }
+    return "  " + strings.Join(parts, "  ")
 }
 
 func (m Model) renderTabContent() string {
-	switch m.activeTab {
-	case TabBody:
-		return m.renderBodyTab()
-	case TabHeaders:
-		return m.headerTable.View()
-	case TabParams:
-		return m.paramTable.View()
-	case TabAuth:
-		return m.renderAuthTab()
-	}
-	return ""
+    switch m.activeTab {
+    case TabBody:
+        return m.renderBodyTab()
+    case TabHeaders:
+        return m.headerTable.View()
+    case TabParams:
+        return m.paramTable.View()
+    case TabAuth:
+        return m.renderAuthTab()
+    }
+    return ""
 }
 
 func (m Model) renderBodyTab() string {
-	// Body mode selector
-	var modes []string
-	for i, label := range bodyModeLabels {
-		if i == m.bodyModeIdx {
-			modes = append(modes, ui.Theme.TabActive.Render("["+label+"]"))
-		} else {
-			modes = append(modes, ui.Theme.TabInactive.Render("["+label+"]"))
-		}
-	}
-	modeBar := "  Mode: " + strings.Join(modes, " ") + "\n\n"
+    var modes []string
+    for i, label := range bodyModeLabels {
+        if i == m.bodyModeIdx {
+            modes = append(modes, ui.Theme.TabActive.Render("["+label+"]"))
+        } else {
+            modes = append(modes, ui.Theme.TabInactive.Render("["+label+"]"))
+        }
+    }
+    modeBar := "  Mode: " + strings.Join(modes, " ") + "\n\n"
 
-	switch bodyModes[m.bodyModeIdx] {
-	case types.BodyModeNone:
-		return modeBar + ui.Theme.Muted.Render("  No body will be sent.")
-	case types.BodyModeRawText, types.BodyModeJSON:
-		return modeBar + m.bodyInput.View()
-	case types.BodyModeForm:
-		return modeBar + m.paramTable.View()
-	}
-	return modeBar
+    switch bodyModes[m.bodyModeIdx] {
+    case types.BodyModeNone:
+        return modeBar + ui.Theme.Muted.Render("  No body will be sent.")
+    case types.BodyModeRawText, types.BodyModeJSON:
+        return modeBar + m.bodyInput.View()
+    case types.BodyModeForm:
+        return modeBar + m.paramTable.View()
+    }
+    return modeBar
 }
 
 func (m Model) renderAuthTab() string {
-	authTypes := []string{"None", "Bearer Token"}
-	var parts []string
-	for i, name := range authTypes {
-		if i == m.authTypeIdx {
-			parts = append(parts, ui.Theme.TabActive.Render("["+name+"]"))
-		} else {
-			parts = append(parts, ui.Theme.TabInactive.Render("["+name+"]"))
-		}
-	}
-	header := "  Auth: " + strings.Join(parts, " ") + "\n\n"
+    authTypes := []string{"None", "Bearer Token"}
+    var parts []string
+    for i, name := range authTypes {
+        if i == m.authTypeIdx {
+            parts = append(parts, ui.Theme.TabActive.Render("["+name+"]"))
+        } else {
+            parts = append(parts, ui.Theme.TabInactive.Render("["+name+"]"))
+        }
+    }
+    header := "  Auth: " + strings.Join(parts, " ") + "\n\n"
 
-	if m.authTypeIdx == 0 {
-		return header + ui.Theme.Muted.Render("  No authentication.")
-	}
+    if m.authTypeIdx == 0 {
+        return header + ui.Theme.Muted.Render("  No authentication.")
+    }
 
-	showHide := ui.Theme.Muted.Render("[ctrl+h toggle]")
-	return header +
-		"  Token: " + m.tokenInput.View() + "  " + showHide
+    showHide := ui.Theme.Muted.Render("[ctrl+h toggle]")
+    return header +
+        "  Token: " + m.tokenInput.View() + "  " + showHide
 }
 
 // SetSize устанавливает размеры компонента.
 func (m Model) SetSize(w, h int) (Model, tea.Cmd) {
-	m.width  = w
-	m.height = h
-	m.urlInput.Width = w - 10
-	m.bodyInput.SetWidth(w - 4)
-	m.bodyInput.SetHeight(h / 3)
-	m.headerTable = m.headerTable.SetWidth(w - 4)
-	m.paramTable  = m.paramTable.SetWidth(w - 4)
-	m.tokenInput.Width = w - 20
-	return m, nil
+    m.width = w
+    m.height = h
+    m.urlInput.Width = w - 10
+    m.bodyInput.SetWidth(w - 4)
+    m.bodyInput.SetHeight(h / 3)
+    m.headerTable = m.headerTable.SetWidth(w - 4)
+    m.paramTable = m.paramTable.SetWidth(w - 4)
+    m.tokenInput.Width = w - 20
+    return m, nil
 }
 
 func (m Model) Width() int  { return m.width }

--- a/internal/requesteditor/model.go
+++ b/internal/requesteditor/model.go
@@ -1,7 +1,9 @@
 package requesteditor
 
 import (
+    "fmt"
     "strings"
+    "time"
 
     "github.com/charmbracelet/bubbles/textarea"
     "github.com/charmbracelet/bubbles/textinput"
@@ -28,7 +30,8 @@ type FocusField int
 const (
     FieldMethod FocusField = iota
     FieldURL
-    FieldTabContent // всё что ниже tab bar
+    FieldTabBar     // строка с табами (Body  Headers  Params  Auth)
+    FieldTabContent // содержимое активной таба (ниже таб бара)
 )
 
 // --- Сообщения вверх в App ---
@@ -145,9 +148,29 @@ func (m Model) LoadRequest(r types.SavedRequest) Model {
     return m
 }
 
-// Clear сбрасывает редактор в пустое состояние.
+// Clear сбрасывает редактор в пустое состояние, полностью сохраняя dimensions и UI состояние.
 func (m Model) Clear() Model {
-    return New()
+    // Save state
+    savedWidth := m.width
+    savedHeight := m.height
+    savedFocusField := m.focusField
+    savedActiveTab := m.activeTab
+
+    // Create completely fresh model
+    m = New()
+
+    // Restore ALL dimensions and UI state
+    m.width = savedWidth
+    m.height = savedHeight
+    m.focusField = savedFocusField
+    m.activeTab = savedActiveTab
+
+    // Re-apply all size-dependent settings by calling SetSize explicitly
+    if savedWidth > 0 && savedHeight > 0 {
+        m.applySize(savedWidth, savedHeight)
+    }
+
+    return m
 }
 
 // CurrentID возвращает ID текущего запроса (для сравнения при удалении).
@@ -198,19 +221,51 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
         // Сохранение всегда как новый
         case "ctrl+s":
             req := m.BuildRequest()
-            // сбрасываем ID, чтобы storage создал новый запрос
-            req.ID = ""
+            // Генерируем новый уникальный ID
+            req.ID = fmt.Sprintf("%d", time.Now().UnixNano())
+            // Генерируем имя на основе метода и URL
+            method := types.HTTPMethods[m.methodIdx]
+            req.Name = method + " request"
+            req.CreatedAt = time.Now()
+            req.UpdatedAt = time.Now()
             m.dirty = false
             return m, func() tea.Msg { return SaveRequestMsg{Request: req} }
 
+        // Переход к URL полю
+        case "ctrl+u":
+            // Blur all inputs
+            m.urlInput.Blur()
+            m.bodyInput.Blur()
+            m.tokenInput.Blur()
+            m.focusField = FieldURL
+            m.urlInput.Focus()
+            return m, nil
+
         case "up":
             switch m.focusField {
+            case FieldMethod:
+                return m, nil
             case FieldURL:
                 m.focusField = FieldMethod
                 return m, nil
+            case FieldTabBar:
+                m.focusField = FieldURL
+                m.urlInput.Focus()
+                return m, nil
             case FieldTabContent:
-                m.activeTab = EditorTab((int(m.activeTab) - 1 + len(tabNames)) % len(tabNames))
-                m = m.focusTabContent()
+                m.focusField = FieldTabBar
+                // Blur current tab content
+                switch m.activeTab {
+                case TabBody:
+                    if bodyModes[m.bodyModeIdx] == types.BodyModeJSON ||
+                        bodyModes[m.bodyModeIdx] == types.BodyModeRawText {
+                        m.bodyInput.Blur()
+                    }
+                case TabAuth:
+                    if m.authTypeIdx == 1 {
+                        m.tokenInput.Blur()
+                    }
+                }
                 return m, nil
             }
         case "down":
@@ -221,12 +276,13 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
                 return m, nil
             case FieldURL:
                 m.urlInput.Blur()
+                m.focusField = FieldTabBar
+                return m, nil
+            case FieldTabBar:
                 m.focusField = FieldTabContent
                 m = m.focusTabContent()
                 return m, nil
             case FieldTabContent:
-                m.activeTab = EditorTab((int(m.activeTab) + 1) % len(tabNames))
-                m = m.focusTabContent()
                 return m, nil
             }
         case "left", "right":
@@ -237,6 +293,14 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
                 }
                 m.methodIdx = (m.methodIdx + delta + len(types.HTTPMethods)) % len(types.HTTPMethods)
                 m.dirty = true
+                return m, nil
+            }
+            if m.focusField == FieldTabBar {
+                delta := 1
+                if msg.String() == "left" {
+                    delta = -1
+                }
+                m.activeTab = EditorTab((int(m.activeTab) + delta + len(tabNames)) % len(tabNames))
                 return m, nil
             }
             if m.focusField == FieldTabContent && m.activeTab == TabBody {
@@ -374,26 +438,18 @@ func (m Model) View() string {
     var sb strings.Builder
 
     methodLine := m.renderMethodSelector()
-    sb.WriteString(methodLine + "\n")
+    sb.WriteString(methodLine + "\n\n")
 
     urlLine := m.renderURLField()
     sb.WriteString(urlLine + "\n")
 
-    if len(m.validationErrs) > 0 {
-        for _, e := range m.validationErrs {
-            sb.WriteString(ui.Theme.Error.Render("  ✗ "+e) + "\n")
-        }
-    }
-
-    sb.WriteString("\n")
-
-    sb.WriteString(m.renderTabBar() + "\n\n")
+    sb.WriteString(m.renderTabBar() + "\n")
 
     sb.WriteString(m.renderTabContent())
 
-    hint := ui.Theme.Muted.Render("  enter send  ctrl+s save as new")
+    hint := ui.Theme.Muted.Render("  enter send  ctrl+s save as new  ctrl+u focus url")
     if m.dirty {
-        hint = ui.Theme.Muted.Render("  enter send  ctrl+s save as new  ") +
+        hint = ui.Theme.Muted.Render("  enter send  ctrl+s save as new  ctrl+u focus url  ") +
             ui.Theme.Error.Render("● unsaved")
     }
     sb.WriteString("\n" + hint)
@@ -422,7 +478,11 @@ func (m Model) renderTabBar() string {
     var parts []string
     for i, name := range tabNames {
         if EditorTab(i) == m.activeTab {
-            parts = append(parts, ui.Theme.TabActive.Render(name))
+            style := ui.Theme.TabActive
+            if m.focusField == FieldTabBar {
+                style = style.Bold(true).Underline(true)
+            }
+            parts = append(parts, style.Render(name))
         } else {
             parts = append(parts, ui.Theme.TabInactive.Render(name))
         }
@@ -453,7 +513,7 @@ func (m Model) renderBodyTab() string {
             modes = append(modes, ui.Theme.TabInactive.Render("["+label+"]"))
         }
     }
-    modeBar := "  Mode: " + strings.Join(modes, " ") + "\n\n"
+    modeBar := "  Mode: " + strings.Join(modes, " ") + "\n"
 
     switch bodyModes[m.bodyModeIdx] {
     case types.BodyModeNone:
@@ -473,7 +533,7 @@ func (m Model) renderAuthTab() string {
         if i == m.authTypeIdx {
             parts = append(parts, ui.Theme.TabActive.Render("["+name+"]"))
         } else {
-            parts = append(parts, ui.Theme.TabInactive.Render("["+name+"]"))
+            parts = append(parts, ui.Theme.TabInactive.Render(name))
         }
     }
     header := "  Auth: " + strings.Join(parts, " ") + "\n\n"
@@ -491,13 +551,33 @@ func (m Model) renderAuthTab() string {
 func (m Model) SetSize(w, h int) (Model, tea.Cmd) {
     m.width = w
     m.height = h
+    m.applySize(w, h)
+    return m, nil
+}
+
+// applySize — общая логика расчёта размеров, чтобы использовать и из SetSize, и из Clear.
+func (m *Model) applySize(w, h int) {
     m.urlInput.Width = w - 10
+
+    // Примерный подсчёт строк:
+    // 1: метод
+    // 1: пустая строка
+    // 1: URL
+    // 1: таб-бар
+    // 1: "Mode: ..." / заголовок таба
+    // 1: подсказка (hint)
+    const reservedLines = 6
+    bodyHeight := h - reservedLines
+    if bodyHeight < 3 {
+        bodyHeight = 3
+    }
+
     m.bodyInput.SetWidth(w - 4)
-    m.bodyInput.SetHeight(h / 3)
+    m.bodyInput.SetHeight(bodyHeight)
+
     m.headerTable = m.headerTable.SetWidth(w - 4)
     m.paramTable = m.paramTable.SetWidth(w - 4)
     m.tokenInput.Width = w - 20
-    return m, nil
 }
 
 func (m Model) Width() int  { return m.width }

--- a/internal/requesteditor/model.go
+++ b/internal/requesteditor/model.go
@@ -1,52 +1,513 @@
 package requesteditor
 
 import (
-    tea "github.com/charmbracelet/bubbletea"
-    "htui/internal/types"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textarea"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"htui/internal/types"
+	"htui/internal/ui"
 )
 
-// Model — заглушка редактора запроса.
-type Model struct {
-    w, h int
-}
+// EditorTab — вкладка в редакторе запроса.
+type EditorTab int
 
-// Сообщения, которые использует app.update.go
+const (
+	TabBody    EditorTab = iota
+	TabHeaders
+	TabParams
+	TabAuth
+)
+
+var tabNames = []string{"Body", "Headers", "Params", "Auth"}
+
+// FocusField — текущий активный элемент внутри editor.
+type FocusField int
+
+const (
+	FieldMethod  FocusField = iota
+	FieldURL
+	FieldTabContent // всё что ниже tab bar
+)
+
+// --- Сообщения вверх в App ---
+
 type SendRequestMsg struct{ Request types.SavedRequest }
 type SaveRequestMsg struct{ Request types.SavedRequest }
 
-func New() Model {
-    return Model{}
+// --- Модель ---
+
+type Model struct {
+	current  types.SavedRequest
+	dirty    bool
+
+	// Поля
+	urlInput    textinput.Model
+	bodyInput   textarea.Model
+	headerTable KVTable
+	paramTable  KVTable
+	bodyModeIdx int // индекс в []BodyMode
+
+	// Auth
+	authTypeIdx  int // 0=none, 1=bearer
+	tokenInput   textinput.Model
+	tokenVisible bool
+
+	// UI-состояние
+	activeTab      EditorTab
+	focusField     FocusField
+	methodIdx      int // индекс в types.HTTPMethods
+	focused        bool
+	width          int
+	height         int
+	validationErrs []string // показываются под URL при ctrl+enter с ошибкой
 }
 
-func (m Model) SetSize(w, h int) (Model, tea.Cmd) {
-    m.w, m.h = w, h
-    return m, nil
+var bodyModes = []types.BodyMode{
+	types.BodyModeNone,
+	types.BodyModeRawText,
+	types.BodyModeJSON,
+	types.BodyModeForm,
 }
+
+var bodyModeLabels = []string{"none", "raw", "json", "form"}
+
+// New создаёт пустой редактор.
+func New() Model {
+	url := textinput.New()
+	url.Placeholder = "https://api.example.com/endpoint"
+	url.CharLimit = 2000
+	url.Focus()
+
+	body := textarea.New()
+	body.Placeholder = "Request body..."
+	body.CharLimit = 0 // без ограничений
+	body.SetHeight(8)
+
+	token := textinput.New()
+	token.Placeholder = "Enter bearer token..."
+	token.EchoMode = textinput.EchoPassword
+	token.CharLimit = 500
+
+	return Model{
+		current:     types.NewSavedRequest(),
+		urlInput:    url,
+		bodyInput:   body,
+		headerTable: NewKVTable(),
+		paramTable:  NewKVTable(),
+		tokenInput:  token,
+		focusField:  FieldURL,
+	}
+}
+
+// LoadRequest загружает существующий запрос в редактор.
+func (m Model) LoadRequest(r types.SavedRequest) Model {
+	m.current     = r
+	m.dirty       = false
+
+	// URL
+	m.urlInput.SetValue(r.URL)
+
+	// Method
+	m.methodIdx = 0
+	for i, method := range types.HTTPMethods {
+		if method == r.Method {
+			m.methodIdx = i
+			break
+		}
+	}
+
+	// Body mode
+	m.bodyModeIdx = 0
+	for i, bm := range bodyModes {
+		if bm == r.BodyMode {
+			m.bodyModeIdx = i
+			break
+		}
+	}
+	m.bodyInput.SetValue(r.Body)
+
+	// Headers / Params
+	m.headerTable = FromHeaders(r.Headers)
+	m.paramTable  = FromParams(r.Params)
+
+	// Auth
+	if r.Auth.Type == types.AuthBearer {
+		m.authTypeIdx = 1
+	} else {
+		m.authTypeIdx = 0
+	}
+	m.tokenInput.SetValue(r.Auth.Token)
+	m.tokenVisible = r.Auth.TokenVisible
+
+	m.validationErrs = nil
+	return m
+}
+
+// Clear сбрасывает редактор в пустое состояние.
+func (m Model) Clear() Model {
+	return New()
+}
+
+// CurrentID возвращает ID текущего запроса (для сравнения при удалении).
+func (m Model) CurrentID() string {
+	return m.current.ID
+}
+
+// BuildRequest собирает types.SavedRequest из текущего состояния полей.
+func (m Model) BuildRequest() types.SavedRequest {
+	r := m.current
+	r.Method   = types.HTTPMethods[m.methodIdx]
+	r.URL      = m.urlInput.Value()
+	r.BodyMode = bodyModes[m.bodyModeIdx]
+	r.Body     = m.bodyInput.Value()
+	r.Headers  = m.headerTable.ToHeaders()
+	r.Params   = m.paramTable.ToParams()
+
+	if m.authTypeIdx == 1 {
+		r.Auth = types.AuthConfig{
+			Type:         types.AuthBearer,
+			Token:        m.tokenInput.Value(),
+			TokenVisible: m.tokenVisible,
+		}
+	} else {
+		r.Auth = types.AuthConfig{Type: types.AuthNone}
+	}
+
+	return r
+}
+
+func (m Model) Init() tea.Cmd { return nil }
 
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
-    // В Task 05 логика не нужна
-    _ = msg
-    return m, nil
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+enter":
+			req := m.BuildRequest()
+			result := Validate(req)
+			if !result.Valid {
+				m.validationErrs = result.Errors
+				return m, nil
+			}
+			m.validationErrs = nil
+			return m, func() tea.Msg { return SendRequestMsg{Request: req} }
+
+		case "ctrl+s":
+			req := m.BuildRequest()
+			m.dirty = false
+			return m, func() tea.Msg { return SaveRequestMsg{Request: req} }
+
+		case "up":
+			switch m.focusField {
+			case FieldURL:
+				m.focusField = FieldMethod
+				return m, nil
+			case FieldTabContent:
+				// Можешь переключаться между вкладками вверх/вниз тоже
+				m.activeTab = EditorTab((int(m.activeTab)-1+len(tabNames)) % len(tabNames))
+				m = m.focusTabContent()
+				return m, nil
+			}
+		case "down":
+			switch m.focusField {
+			case FieldMethod:
+				m.focusField = FieldURL
+				m.urlInput.Focus()
+				return m, nil
+			case FieldURL:
+				m.urlInput.Blur()
+				m.focusField = FieldTabContent
+				m = m.focusTabContent()
+				return m, nil
+			case FieldTabContent:
+				// Переключение между вкладками вниз
+				m.activeTab = EditorTab((int(m.activeTab)+1) % len(tabNames))
+				m = m.focusTabContent()
+				return m, nil
+			}
+		case "left", "right":
+			if m.focusField == FieldMethod {
+				delta := 1
+				if msg.String() == "left" {
+					delta = -1
+				}
+				m.methodIdx = (m.methodIdx + delta + len(types.HTTPMethods)) % len(types.HTTPMethods)
+				m.dirty = true
+				return m, nil
+			}
+			// Left/Right на Body вкладке работают для Mode selector
+			if m.focusField == FieldTabContent && m.activeTab == TabBody {
+				switch msg.String() {
+				case "left":
+					if m.bodyModeIdx > 0 {
+						m.bodyModeIdx--
+						m.dirty = true
+						m = m.focusTabContent()
+					}
+					return m, nil
+				case "right":
+					if m.bodyModeIdx < len(bodyModes)-1 {
+						m.bodyModeIdx++
+						m.dirty = true
+						m = m.focusTabContent()
+					}
+					return m, nil
+				}
+			}
+
+		case "1", "2", "3", "4", "5":
+			// Быстрый выбор метода цифрами
+			idx := int(msg.String()[0]-'1')
+			if idx < len(types.HTTPMethods) {
+				m.methodIdx = idx
+				m.dirty = true
+			}
+			return m, nil
+		}
+	}
+
+	// Роутинг к активному полю
+	return m.routeToActiveField(msg)
+}
+
+// routeToActiveField передаёт сообщение в текущий активный subcomponent.
+func (m Model) routeToActiveField(msg tea.Msg) (Model, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch m.focusField {
+	case FieldURL:
+		m.urlInput, cmd = m.urlInput.Update(msg)
+		m.dirty = true
+
+	case FieldTabContent:
+		switch m.activeTab {
+		case TabBody:
+			if msg, ok := msg.(tea.KeyMsg); ok {
+				switch msg.String() {
+				case "down":
+					// Переход из Mode selector на editor если режим не none
+					if bodyModes[m.bodyModeIdx] != types.BodyModeNone {
+						if bodyModes[m.bodyModeIdx] == types.BodyModeJSON ||
+							bodyModes[m.bodyModeIdx] == types.BodyModeRawText {
+							m.bodyInput.Focus()
+						} else if bodyModes[m.bodyModeIdx] == types.BodyModeForm {
+							// Фокус на таблицу параметров
+						}
+					}
+					return m, nil
+				}
+			}
+			if bodyModes[m.bodyModeIdx] == types.BodyModeJSON ||
+				bodyModes[m.bodyModeIdx] == types.BodyModeRawText {
+				m.bodyInput, cmd = m.bodyInput.Update(msg)
+				m.dirty = true
+			} else if bodyModes[m.bodyModeIdx] == types.BodyModeForm {
+				m.paramTable, cmd = m.paramTable.Update(msg)
+				m.dirty = true
+			}
+
+		case TabHeaders:
+			m.headerTable, cmd = m.headerTable.Update(msg)
+			m.dirty = true
+
+		case TabParams:
+			m.paramTable, cmd = m.paramTable.Update(msg)
+			m.dirty = true
+
+		case TabAuth:
+			m = m.updateAuthTab(msg)
+		}
+	}
+	return m, cmd
+}
+
+func (m Model) updateAuthTab(msg tea.Msg) Model {
+	var cmd tea.Cmd
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "left", "right":
+			m.authTypeIdx = (m.authTypeIdx + 1) % 2
+			if m.authTypeIdx == 1 {
+				m.tokenInput.Focus()
+			} else {
+				m.tokenInput.Blur()
+			}
+			m.dirty = true
+			return m
+		case "ctrl+h": // show/hide token
+			m.tokenVisible = !m.tokenVisible
+			if m.tokenVisible {
+				m.tokenInput.EchoMode = textinput.EchoNormal
+			} else {
+				m.tokenInput.EchoMode = textinput.EchoPassword
+			}
+			return m
+		}
+	}
+	if m.authTypeIdx == 1 {
+		m.tokenInput, cmd = m.tokenInput.Update(msg)
+		_ = cmd
+		m.dirty = true
+	}
+	return m
+}
+
+func (m Model) focusTabContent() Model {
+	switch m.activeTab {
+	case TabBody:
+		if bodyModes[m.bodyModeIdx] != types.BodyModeNone {
+			m.bodyInput.Focus()
+		}
+	case TabAuth:
+		if m.authTypeIdx == 1 {
+			m.tokenInput.Focus()
+		}
+	}
+	return m
 }
 
 func (m Model) View() string {
-    return "Editor"
+	if m.width == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+
+	// --- Строка метода + URL ---
+	methodLine := m.renderMethodSelector()
+	sb.WriteString(methodLine + "\n")
+
+	urlLine := m.renderURLField()
+	sb.WriteString(urlLine + "\n")
+
+	// Ошибки валидации
+	if len(m.validationErrs) > 0 {
+		for _, e := range m.validationErrs {
+			sb.WriteString(ui.Theme.Error.Render("  ✗ "+e) + "\n")
+		}
+	}
+
+	sb.WriteString("\n")
+
+	// --- Tab bar ---
+	sb.WriteString(m.renderTabBar() + "\n\n")
+
+	// --- Содержимое вкладки ---
+	sb.WriteString(m.renderTabContent())
+
+	// --- Подсказка ---
+	hint := ui.Theme.Muted.Render("  ctrl+enter send  ctrl+s save")
+	if m.dirty {
+		hint = ui.Theme.Muted.Render("  ctrl+enter send  ctrl+s save  ") +
+			ui.Theme.Error.Render("● unsaved")
+	}
+	sb.WriteString("\n" + hint)
+
+	return sb.String()
 }
 
-func (m Model) Width() int  { return m.w }
-func (m Model) Height() int { return m.h }
-
-// LoadRequest — заглушка загрузки сохранённого запроса.
-func (m Model) LoadRequest(_ types.SavedRequest) Model {
-    return m
+func (m Model) renderMethodSelector() string {
+	var parts []string
+	for i, method := range types.HTTPMethods {
+		style := ui.Theme.Muted
+		if i == m.methodIdx {
+			style = ui.MethodStyle(method).Bold(true)
+		}
+		parts = append(parts, style.Render("["+method+"]"))
+	}
+	return "  " + strings.Join(parts, " ")
 }
 
-// Clear — заглушка очистки редактора.
-func (m Model) Clear() Model {
-    return m
+func (m Model) renderURLField() string {
+	label := ui.Theme.Muted.Render("  URL: ")
+	return label + m.urlInput.View()
 }
 
-// CurrentID — ID текущего запроса, в заглушке пустой.
-func (m Model) CurrentID() string {
-    return ""
+func (m Model) renderTabBar() string {
+	var parts []string
+	for i, name := range tabNames {
+		if EditorTab(i) == m.activeTab {
+			parts = append(parts, ui.Theme.TabActive.Render(name))
+		} else {
+			parts = append(parts, ui.Theme.TabInactive.Render(name))
+		}
+	}
+	return "  " + strings.Join(parts, "  ")
 }
+
+func (m Model) renderTabContent() string {
+	switch m.activeTab {
+	case TabBody:
+		return m.renderBodyTab()
+	case TabHeaders:
+		return m.headerTable.View()
+	case TabParams:
+		return m.paramTable.View()
+	case TabAuth:
+		return m.renderAuthTab()
+	}
+	return ""
+}
+
+func (m Model) renderBodyTab() string {
+	// Body mode selector
+	var modes []string
+	for i, label := range bodyModeLabels {
+		if i == m.bodyModeIdx {
+			modes = append(modes, ui.Theme.TabActive.Render("["+label+"]"))
+		} else {
+			modes = append(modes, ui.Theme.TabInactive.Render("["+label+"]"))
+		}
+	}
+	modeBar := "  Mode: " + strings.Join(modes, " ") + "\n\n"
+
+	switch bodyModes[m.bodyModeIdx] {
+	case types.BodyModeNone:
+		return modeBar + ui.Theme.Muted.Render("  No body will be sent.")
+	case types.BodyModeRawText, types.BodyModeJSON:
+		return modeBar + m.bodyInput.View()
+	case types.BodyModeForm:
+		return modeBar + m.paramTable.View()
+	}
+	return modeBar
+}
+
+func (m Model) renderAuthTab() string {
+	authTypes := []string{"None", "Bearer Token"}
+	var parts []string
+	for i, name := range authTypes {
+		if i == m.authTypeIdx {
+			parts = append(parts, ui.Theme.TabActive.Render("["+name+"]"))
+		} else {
+			parts = append(parts, ui.Theme.TabInactive.Render("["+name+"]"))
+		}
+	}
+	header := "  Auth: " + strings.Join(parts, " ") + "\n\n"
+
+	if m.authTypeIdx == 0 {
+		return header + ui.Theme.Muted.Render("  No authentication.")
+	}
+
+	showHide := ui.Theme.Muted.Render("[ctrl+h toggle]")
+	return header +
+		"  Token: " + m.tokenInput.View() + "  " + showHide
+}
+
+// SetSize устанавливает размеры компонента.
+func (m Model) SetSize(w, h int) (Model, tea.Cmd) {
+	m.width  = w
+	m.height = h
+	m.urlInput.Width = w - 10
+	m.bodyInput.SetWidth(w - 4)
+	m.bodyInput.SetHeight(h / 3)
+	m.headerTable = m.headerTable.SetWidth(w - 4)
+	m.paramTable  = m.paramTable.SetWidth(w - 4)
+	m.tokenInput.Width = w - 20
+	return m, nil
+}
+
+func (m Model) Width() int  { return m.width }
+func (m Model) Height() int { return m.height }

--- a/internal/requesteditor/validation.go
+++ b/internal/requesteditor/validation.go
@@ -1,0 +1,58 @@
+package requesteditor
+
+import (
+	"encoding/json"
+	"net/url"
+	"htui/internal/types"
+)
+
+// ValidationResult — результат проверки запроса перед отправкой.
+type ValidationResult struct {
+	Valid    bool
+	Errors   []string // блокирующие ошибки (не отправляем)
+	Warnings []string // предупреждения (отправляем, но предупреждаем)
+}
+
+// Validate проверяет запрос перед отправкой.
+// Errors — блокируют отправку. Warnings — нет.
+func Validate(r types.SavedRequest) ValidationResult {
+	var res ValidationResult
+	res.Valid = true
+
+	// 1. URL не пустой
+	if r.URL == "" {
+		res.Valid = false
+		res.Errors = append(res.Errors, "URL is required")
+		return res
+	}
+
+	// 2. URL парсится (с учётом авто-схемы)
+	testURL := r.URL
+	if len(testURL) > 0 && !hasScheme(testURL) {
+		testURL = "https://" + testURL
+	}
+	if _, err := url.ParseRequestURI(testURL); err != nil {
+		res.Valid = false
+		res.Errors = append(res.Errors, "Invalid URL: "+err.Error())
+	}
+
+	// 3. JSON body валиден
+	if r.BodyMode == types.BodyModeJSON && r.Body != "" {
+		if !json.Valid([]byte(r.Body)) {
+			res.Valid = false
+			res.Errors = append(res.Errors, "Invalid JSON in request body")
+		}
+	}
+
+	// 4. Bearer без токена — предупреждение (не блокирующее)
+	if r.Auth.Type == types.AuthBearer && r.Auth.Token == "" {
+		res.Warnings = append(res.Warnings, "Bearer token is empty")
+	}
+
+	return res
+}
+
+func hasScheme(u string) bool {
+	return len(u) > 4 &&
+		(u[:7] == "http://" || u[:8] == "https://")
+}

--- a/internal/responsedisplay/formatter.go
+++ b/internal/responsedisplay/formatter.go
@@ -1,0 +1,93 @@
+package responsedisplay
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"htui/internal/types"
+)
+
+// FormatBody форматирует тело ответа для отображения.
+// JSON → pretty-print. Бинарный → информационное сообщение. Иначе → как есть.
+//
+// АРХИТЕКТУРНАЯ ЗАКЛАДКА:
+// Функция принимает готовый ResponseData.Body (string).
+// В будущей версии со стримингом эта же функция будет вызываться
+// для каждого накопленного чанка из chan []byte — сигнатура не изменится,
+// изменится только момент вызова (не после полного получения, а пошагово).
+func FormatBody(data types.ResponseData) string {
+	if data.IsBinary {
+		return fmt.Sprintf("[Binary response received: %s]", FormatBytes(data.SizeBytes))
+	}
+	if data.Body == "" {
+		return "(empty response body)"
+	}
+	if isJSON(data) {
+		if pretty, err := prettyJSON(data.Body); err == nil {
+			return pretty
+		}
+	}
+	return data.Body
+}
+
+// FormatHeaders форматирует заголовки ответа для отображения.
+func FormatHeaders(headers []types.Header) string {
+	if len(headers) == 0 {
+		return "(no headers)"
+	}
+	var sb strings.Builder
+	for _, h := range headers {
+		sb.WriteString(fmt.Sprintf("%-30s %s\n", h.Key+":", h.Value))
+	}
+	return sb.String()
+}
+
+// FormatBytes форматирует размер в читаемый вид.
+func FormatBytes(n int) string {
+	switch {
+	case n < 1024:
+		return fmt.Sprintf("%d B", n)
+	case n < 1024*1024:
+		return fmt.Sprintf("%.1f KB", float64(n)/1024)
+	default:
+		return fmt.Sprintf("%.1f MB", float64(n)/(1024*1024))
+	}
+}
+
+// FormatDuration форматирует время выполнения в читаемый вид.
+func FormatDuration(ms int64) string {
+	switch {
+	case ms < 1000:
+		return fmt.Sprintf("%d ms", ms)
+	default:
+		return fmt.Sprintf("%.2f s", float64(ms)/1000)
+	}
+}
+
+// isJSON определяет является ли ответ JSON по Content-Type или попытке парсинга.
+func isJSON(data types.ResponseData) bool {
+	for _, h := range data.Headers {
+		if strings.EqualFold(h.Key, "Content-Type") {
+			if strings.Contains(h.Value, "application/json") ||
+				strings.Contains(h.Value, "text/json") {
+				return true
+			}
+		}
+	}
+	// Fallback: попробовать распарсить
+	return json.Valid([]byte(strings.TrimSpace(data.Body)))
+}
+
+// prettyJSON форматирует JSON строку с отступами.
+func prettyJSON(s string) (string, error) {
+	var v any
+	if err := json.Unmarshal([]byte(s), &v); err != nil {
+		return "", err
+	}
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/internal/responsedisplay/model.go
+++ b/internal/responsedisplay/model.go
@@ -1,231 +1,242 @@
 package responsedisplay
 
 import (
-	"fmt"
-	"strings"
+    "fmt"
+    "strings"
 
-	"github.com/charmbracelet/bubbles/spinner"
-	"github.com/charmbracelet/bubbles/viewport"
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
+    "github.com/charmbracelet/bubbles/spinner"
+    "github.com/charmbracelet/bubbles/viewport"
+    tea "github.com/charmbracelet/bubbletea"
+    "github.com/charmbracelet/lipgloss"
 
-	"htui/internal/types"
-	"htui/internal/ui"
+    "htui/internal/types"
+    "htui/internal/ui"
 )
 
 // ResponseTab — вкладка ответа.
 type ResponseTab int
 
 const (
-	TabBody    ResponseTab = iota
-	TabHeaders
+    TabBody ResponseTab = iota
+    TabHeaders
 )
 
 // Model — компонент отображения ответа.
 type Model struct {
-	data      *types.ResponseData // nil = пустое состояние
-	loading   bool
-	activeTab ResponseTab
+    data      *types.ResponseData // nil = пустое состояние
+    loading   bool
+    activeTab ResponseTab
 
-	bodyVP    viewport.Model
-	headersVP viewport.Model
-	spinner   spinner.Model
+    bodyVP    viewport.Model
+    headersVP viewport.Model
+    spinner   spinner.Model
 
-	focused bool
-	width   int
-	height  int
-	ready   bool // false пока не установлены размеры
+    focused bool
+    width   int
+    height  int
+    ready   bool // false пока не установлены размеры
 }
 
 // New создаёт пустой компонент ответа.
 func New() Model {
-	s := spinner.New()
-	s.Spinner = spinner.Dot
-	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("62"))
+    s := spinner.New()
+    s.Spinner = spinner.Dot
+    s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("62"))
 
-	return Model{
-		spinner: s,
-	}
+    return Model{
+        spinner: s,
+    }
 }
 
 func (m Model) Init() tea.Cmd {
-	return nil
+    return nil
 }
 
 // SetSize устанавливает размеры и инициализирует viewport.
 func (m Model) SetSize(w, h int) (Model, tea.Cmd) {
-	// Guard против нулевых размеров
-	if w < 5 || h < 5 {
-		m.width = w
-		m.height = h
-		m.ready = true
-		return m, nil
-	}
+    // Guard против нулевых размеров
+    if w < 5 || h < 5 {
+        m.width = w
+        m.height = h
+        m.ready = true
+        return m, nil
+    }
 
-	m.width = w
-	m.height = h
-	m.ready = true
+    m.width = w
+    m.height = h
+    m.ready = true
 
-	// Статус-бар: 2 строки. Tab bar: 2 строки. Отступы: 2 строки.
-	const reservedLines = 6
-	vpHeight := h - reservedLines
-	if vpHeight < 1 {
-		vpHeight = 1
-	}
+    // Статус-бар: 2 строки. Tab bar: 2 строки. Отступы: 2 строки.
+    const reservedLines = 6
+    vpHeight := h - reservedLines
+    if vpHeight < 1 {
+        vpHeight = 1
+    }
 
-	m.bodyVP = viewport.New(w, vpHeight)
-	m.headersVP = viewport.New(w, vpHeight)
+    m.bodyVP = viewport.New(w, vpHeight)
+    m.headersVP = viewport.New(w, vpHeight)
 
-	// Перезаполнить viewport если данные уже есть
-	if m.data != nil {
-		m.bodyVP.SetContent(FormatBody(*m.data))
-		m.headersVP.SetContent(FormatHeaders(m.data.Headers))
-	}
-	return m, nil
+    // Перезаполнить viewport если данные уже есть
+    if m.data != nil {
+        m.bodyVP.SetContent(FormatBody(*m.data))
+        m.headersVP.SetContent(FormatHeaders(m.data.Headers))
+    }
+    return m, nil
 }
 
 // SetLoading включает/выключает спиннер.
 func (m Model) SetLoading(loading bool) Model {
-	m.loading = loading
-	return m
+    m.loading = loading
+    return m
 }
 
 // SetResponse загружает данные ответа и обновляет viewport.
 func (m Model) SetResponse(data types.ResponseData) Model {
-	m.data = &data
-	m.loading = false
+    m.data = &data
+    m.loading = false
 
-	if m.ready {
-		m.bodyVP.SetContent(FormatBody(data))
-		m.headersVP.SetContent(FormatHeaders(data.Headers))
-		m.bodyVP.GotoTop()
-		m.headersVP.GotoTop()
-	}
-	return m
+    if m.ready {
+        m.bodyVP.SetContent(FormatBody(data))
+        m.headersVP.SetContent(FormatHeaders(data.Headers))
+        m.bodyVP.GotoTop()
+        m.headersVP.GotoTop()
+    }
+    return m
 }
 
 // UpdateSpinner обновляет спиннер (вызывается из root App при spinner.TickMsg).
 func (m Model) UpdateSpinner(msg tea.Msg) (Model, tea.Cmd) {
-	var cmd tea.Cmd
-	m.spinner, cmd = m.spinner.Update(msg)
-	return m, cmd
+    var cmd tea.Cmd
+    m.spinner, cmd = m.spinner.Update(msg)
+    return m, cmd
 }
 
 // SpinnerCmd возвращает команду для запуска спиннера.
 func (m Model) SpinnerCmd() tea.Cmd {
-	return m.spinner.Tick
+    return m.spinner.Tick
 }
 
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
-	if !m.ready {
-		return m, nil
-	}
+    if !m.ready {
+        return m, nil
+    }
 
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch msg.String() {
-		case "tab":
-			if m.activeTab == TabBody {
-				m.activeTab = TabHeaders
-			} else {
-				m.activeTab = TabBody
-			}
-			return m, nil
-		}
-		// Прокрутка активного viewport
-		var cmd tea.Cmd
-		if m.activeTab == TabBody {
-			m.bodyVP, cmd = m.bodyVP.Update(msg)
-		} else {
-			m.headersVP, cmd = m.headersVP.Update(msg)
-		}
-		return m, cmd
-	}
+    switch msg := msg.(type) {
+    case tea.KeyMsg:
+        switch msg.String() {
+        case "left":
+            // Переключение вкладки влево
+            if m.activeTab == TabHeaders {
+                m.activeTab = TabBody
+            }
+            return m, nil
+        case "right":
+            // Переключение вкладки вправо
+            if m.activeTab == TabBody {
+                m.activeTab = TabHeaders
+            }
+            return m, nil
+        }
 
-	// Другие сообщения (например WindowSizeMsg переданный повторно)
-	var cmd tea.Cmd
-	if m.activeTab == TabBody {
-		m.bodyVP, cmd = m.bodyVP.Update(msg)
-	} else {
-		m.headersVP, cmd = m.headersVP.Update(msg)
-	}
-	return m, cmd
+        // Прокрутка активного viewport
+        var cmd tea.Cmd
+        if m.activeTab == TabBody {
+            m.bodyVP, cmd = m.bodyVP.Update(msg)
+        } else {
+            m.headersVP, cmd = m.headersVP.Update(msg)
+        }
+        return m, cmd
+    }
+
+    // Другие сообщения (например WindowSizeMsg переданный повторно)
+    var cmd tea.Cmd
+    if m.activeTab == TabBody {
+        m.bodyVP, cmd = m.bodyVP.Update(msg)
+    } else {
+        m.headersVP, cmd = m.headersVP.Update(msg)
+    }
+    return m, cmd
 }
 
 func (m Model) View() string {
-	if !m.ready {
-		return lipgloss.Place(
-			m.width, m.height,
-			lipgloss.Center, lipgloss.Center,
-			ui.Theme.Muted.Render("Loading..."),
-		)
-	}
+    if !m.ready {
+        return lipgloss.Place(
+            m.width, m.height,
+            lipgloss.Center, lipgloss.Center,
+            ui.Theme.Muted.Render("Loading..."),
+        )
+    }
 
-	if m.loading {
-		return lipgloss.Place(
-			m.width, m.height,
-			lipgloss.Center, lipgloss.Center,
-			m.spinner.View()+"  Sending request...",
-		)
-	}
+    if m.loading {
+        return lipgloss.Place(
+            m.width, m.height,
+            lipgloss.Center, lipgloss.Center,
+            m.spinner.View()+"  Sending request...",
+        )
+    }
 
-	if m.data == nil {
-		return lipgloss.Place(
-			m.width, m.height,
-			lipgloss.Center, lipgloss.Center,
-			ui.Theme.Muted.Render("Press ")+
-				ui.Theme.Highlight.Render("ctrl+enter")+
-				ui.Theme.Muted.Render(" to send a request.\n\nResponse will appear here."),
-		)
-	}
+    if m.data == nil {
+        return lipgloss.Place(
+            m.width, m.height,
+            lipgloss.Center, lipgloss.Center,
+            ui.Theme.Muted.Render("Press ")+
+                ui.Theme.Highlight.Render("ctrl+enter")+
+                ui.Theme.Muted.Render(" to send a request.\n\nResponse will appear here."),
+        )
+    }
 
-	if m.data.IsError() {
-		return lipgloss.Place(
-			m.width, m.height,
-			lipgloss.Center, lipgloss.Center,
-			ui.Theme.Error.Render("Request failed\n\n")+
-				ui.Theme.Muted.Render(m.data.Error),
-		)
-	}
+    if m.data.IsError() {
+        return lipgloss.Place(
+            m.width, m.height,
+            lipgloss.Center, lipgloss.Center,
+            ui.Theme.Error.Render("Request failed\n\n")+
+                ui.Theme.Muted.Render(m.data.Error),
+        )
+    }
 
-	var sb strings.Builder
+    var sb strings.Builder
 
-	// Статус-бар
-	sb.WriteString(m.renderStatusBar() + "\n\n")
+    // Статус-бар
+    sb.WriteString(m.renderStatusBar() + "\n\n")
 
-	// Tab bar
-	sb.WriteString(m.renderTabBar() + "\n\n")
+    // Tab bar
+    sb.WriteString(m.renderTabBar() + "\n\n")
 
-	// Контент
-	if m.activeTab == TabBody {
-		sb.WriteString(m.bodyVP.View())
-	} else {
-		sb.WriteString(m.headersVP.View())
-	}
+    // Контент
+    if m.activeTab == TabBody {
+        sb.WriteString(m.bodyVP.View())
+    } else {
+        sb.WriteString(m.headersVP.View())
+    }
 
-	return sb.String()
+    return sb.String()
 }
 
 func (m Model) renderStatusBar() string {
-	statusStyle := ui.StatusStyle(m.data.StatusCode)
-	status := statusStyle.Render(m.data.StatusText)
-	duration := ui.Theme.Muted.Render(FormatDuration(m.data.DurationMs))
-	size := ui.Theme.Muted.Render(FormatBytes(m.data.SizeBytes))
-	sep := ui.Theme.Muted.Render("  │  ")
-	return fmt.Sprintf("  %s%s%s%s%s", status, sep, duration, sep, size)
+    statusStyle := ui.StatusStyle(m.data.StatusCode)
+    status := statusStyle.Render(m.data.StatusText)
+    duration := ui.Theme.Muted.Render(FormatDuration(m.data.DurationMs))
+    size := ui.Theme.Muted.Render(FormatBytes(m.data.SizeBytes))
+    sep := ui.Theme.Muted.Render("  │  ")
+    shortcut := ui.Theme.Muted.Render("←/→: switch Body/Headers")
+
+    return fmt.Sprintf("  %s%s%s%s%s%s%s",
+        status, sep, duration, sep, size, sep, shortcut,
+    )
 }
 
 func (m Model) renderTabBar() string {
-	tabs := []string{"Body", "Headers"}
-	var parts []string
-	for i, name := range tabs {
-		if ResponseTab(i) == m.activeTab {
-			parts = append(parts, ui.Theme.TabActive.Render(name))
-		} else {
-			parts = append(parts, ui.Theme.TabInactive.Render(name))
-		}
-	}
-	return "  " + strings.Join(parts, "  ")
+    tabs := []string{"Body", "Headers"}
+    var parts []string
+    for i, name := range tabs {
+        label := "[" + name + "]"
+        if ResponseTab(i) == m.activeTab {
+            parts = append(parts, ui.Theme.TabActive.Render(label))
+        } else {
+            parts = append(parts, ui.Theme.TabInactive.Render(label))
+        }
+    }
+    return "  " + strings.Join(parts, "  ")
 }
 
 // Width / Height для App.renderPanel

--- a/internal/responsedisplay/model.go
+++ b/internal/responsedisplay/model.go
@@ -1,242 +1,246 @@
 package responsedisplay
 
 import (
-    "fmt"
-    "strings"
+	"fmt"
+	"strings"
 
-    "github.com/charmbracelet/bubbles/spinner"
-    "github.com/charmbracelet/bubbles/viewport"
-    tea "github.com/charmbracelet/bubbletea"
-    "github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
-    "htui/internal/types"
-    "htui/internal/ui"
+	"htui/internal/types"
+	"htui/internal/ui"
 )
 
 // ResponseTab — вкладка ответа.
 type ResponseTab int
 
 const (
-    TabBody ResponseTab = iota
-    TabHeaders
+	TabBody ResponseTab = iota
+	TabHeaders
 )
 
 // Model — компонент отображения ответа.
 type Model struct {
-    data      *types.ResponseData // nil = пустое состояние
-    loading   bool
-    activeTab ResponseTab
+	data      *types.ResponseData // nil = пустое состояние
+	loading   bool
+	activeTab ResponseTab
 
-    bodyVP    viewport.Model
-    headersVP viewport.Model
-    spinner   spinner.Model
+	bodyVP    viewport.Model
+	headersVP viewport.Model
+	spinner   spinner.Model
 
-    focused bool
-    width   int
-    height  int
-    ready   bool // false пока не установлены размеры
+	focused bool
+	width   int
+	height  int
+	ready   bool // false пока не установлены размеры
+
+	demoRequestName string // имя демо-запроса для отображения в empty state
 }
 
 // New создаёт пустой компонент ответа.
 func New() Model {
-    s := spinner.New()
-    s.Spinner = spinner.Dot
-    s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("62"))
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("62"))
 
-    return Model{
-        spinner: s,
-    }
+	return Model{
+		spinner: s,
+	}
 }
 
 func (m Model) Init() tea.Cmd {
-    return nil
+	return nil
 }
 
 // SetSize устанавливает размеры и инициализирует viewport.
 func (m Model) SetSize(w, h int) (Model, tea.Cmd) {
-    // Guard против нулевых размеров
-    if w < 5 || h < 5 {
-        m.width = w
-        m.height = h
-        m.ready = true
-        return m, nil
-    }
+	if w < 5 || h < 5 {
+		m.width = w
+		m.height = h
+		m.ready = true
+		return m, nil
+	}
 
-    m.width = w
-    m.height = h
-    m.ready = true
+	m.width = w
+	m.height = h
+	m.ready = true
 
-    // Статус-бар: 2 строки. Tab bar: 2 строки. Отступы: 2 строки.
-    const reservedLines = 6
-    vpHeight := h - reservedLines
-    if vpHeight < 1 {
-        vpHeight = 1
-    }
+	const reservedLines = 6
+	vpHeight := h - reservedLines
+	if vpHeight < 1 {
+		vpHeight = 1
+	}
 
-    m.bodyVP = viewport.New(w, vpHeight)
-    m.headersVP = viewport.New(w, vpHeight)
+	m.bodyVP = viewport.New(w, vpHeight)
+	m.headersVP = viewport.New(w, vpHeight)
 
-    // Перезаполнить viewport если данные уже есть
-    if m.data != nil {
-        m.bodyVP.SetContent(FormatBody(*m.data))
-        m.headersVP.SetContent(FormatHeaders(m.data.Headers))
-    }
-    return m, nil
+	if m.data != nil {
+		m.bodyVP.SetContent(FormatBody(*m.data))
+		m.headersVP.SetContent(FormatHeaders(m.data.Headers))
+	}
+
+	return m, nil
 }
 
 // SetLoading включает/выключает спиннер.
 func (m Model) SetLoading(loading bool) Model {
-    m.loading = loading
-    return m
+	m.loading = loading
+	return m
 }
 
 // SetResponse загружает данные ответа и обновляет viewport.
 func (m Model) SetResponse(data types.ResponseData) Model {
-    m.data = &data
-    m.loading = false
+	m.data = &data
+	m.loading = false
 
-    if m.ready {
-        m.bodyVP.SetContent(FormatBody(data))
-        m.headersVP.SetContent(FormatHeaders(data.Headers))
-        m.bodyVP.GotoTop()
-        m.headersVP.GotoTop()
-    }
-    return m
+	if m.ready {
+		m.bodyVP.SetContent(FormatBody(data))
+		m.headersVP.SetContent(FormatHeaders(data.Headers))
+		m.bodyVP.GotoTop()
+		m.headersVP.GotoTop()
+	}
+	return m
 }
 
-// UpdateSpinner обновляет спиннер (вызывается из root App при spinner.TickMsg).
+// UpdateSpinner обновляет спиннер.
 func (m Model) UpdateSpinner(msg tea.Msg) (Model, tea.Cmd) {
-    var cmd tea.Cmd
-    m.spinner, cmd = m.spinner.Update(msg)
-    return m, cmd
+	var cmd tea.Cmd
+	m.spinner, cmd = m.spinner.Update(msg)
+	return m, cmd
 }
 
 // SpinnerCmd возвращает команду для запуска спиннера.
 func (m Model) SpinnerCmd() tea.Cmd {
-    return m.spinner.Tick
+	return m.spinner.Tick
 }
 
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
-    if !m.ready {
-        return m, nil
-    }
+	if !m.ready {
+		return m, nil
+	}
 
-    switch msg := msg.(type) {
-    case tea.KeyMsg:
-        switch msg.String() {
-        case "left":
-            // Переключение вкладки влево
-            if m.activeTab == TabHeaders {
-                m.activeTab = TabBody
-            }
-            return m, nil
-        case "right":
-            // Переключение вкладки вправо
-            if m.activeTab == TabBody {
-                m.activeTab = TabHeaders
-            }
-            return m, nil
-        }
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "left":
+			if m.activeTab == TabHeaders {
+				m.activeTab = TabBody
+			}
+			return m, nil
+		case "right":
+			if m.activeTab == TabBody {
+				m.activeTab = TabHeaders
+			}
+			return m, nil
+		}
 
-        // Прокрутка активного viewport
-        var cmd tea.Cmd
-        if m.activeTab == TabBody {
-            m.bodyVP, cmd = m.bodyVP.Update(msg)
-        } else {
-            m.headersVP, cmd = m.headersVP.Update(msg)
-        }
-        return m, cmd
-    }
+		var cmd tea.Cmd
+		if m.activeTab == TabBody {
+			m.bodyVP, cmd = m.bodyVP.Update(msg)
+		} else {
+			m.headersVP, cmd = m.headersVP.Update(msg)
+		}
+		return m, cmd
+	}
 
-    // Другие сообщения (например WindowSizeMsg переданный повторно)
-    var cmd tea.Cmd
-    if m.activeTab == TabBody {
-        m.bodyVP, cmd = m.bodyVP.Update(msg)
-    } else {
-        m.headersVP, cmd = m.headersVP.Update(msg)
-    }
-    return m, cmd
+	var cmd tea.Cmd
+	if m.activeTab == TabBody {
+		m.bodyVP, cmd = m.bodyVP.Update(msg)
+	} else {
+		m.headersVP, cmd = m.headersVP.Update(msg)
+	}
+	return m, cmd
 }
 
+// View рендерит компонент.
 func (m Model) View() string {
-    if !m.ready {
-        return lipgloss.Place(
-            m.width, m.height,
-            lipgloss.Center, lipgloss.Center,
-            ui.Theme.Muted.Render("Loading..."),
-        )
-    }
+	if !m.ready {
+		return lipgloss.Place(
+			m.width, m.height,
+			lipgloss.Center, lipgloss.Center,
+			ui.Theme.Muted.Render("Loading..."),
+		)
+	}
 
-    if m.loading {
-        return lipgloss.Place(
-            m.width, m.height,
-            lipgloss.Center, lipgloss.Center,
-            m.spinner.View()+"  Sending request...",
-        )
-    }
+	if m.loading {
+		return lipgloss.Place(
+			m.width, m.height,
+			lipgloss.Center, lipgloss.Center,
+			m.spinner.View()+"  Sending request...",
+		)
+	}
 
-    if m.data == nil {
-        return lipgloss.Place(
-            m.width, m.height,
-            lipgloss.Center, lipgloss.Center,
-            ui.Theme.Muted.Render("Press ")+
-                ui.Theme.Highlight.Render("ctrl+enter")+
-                ui.Theme.Muted.Render(" to send a request.\n\nResponse will appear here."),
-        )
-    }
+	// Empty state
+	if m.data == nil {
+		emptyMsg := "Press ctrl+enter to send a request.\n\nResponse will appear here."
+		if m.demoRequestName != "" {
+			emptyMsg = fmt.Sprintf("Demo Request: %s\n\n%s", m.demoRequestName, emptyMsg)
+		}
+		return lipgloss.Place(
+			m.width, m.height,
+			lipgloss.Center, lipgloss.Center,
+			ui.Theme.Muted.Render(emptyMsg),
+		)
+	}
 
-    if m.data.IsError() {
-        return lipgloss.Place(
-            m.width, m.height,
-            lipgloss.Center, lipgloss.Center,
-            ui.Theme.Error.Render("Request failed\n\n")+
-                ui.Theme.Muted.Render(m.data.Error),
-        )
-    }
+	// Error state
+	if m.data.IsError() {
+		return lipgloss.Place(
+			m.width, m.height,
+			lipgloss.Center, lipgloss.Center,
+			ui.Theme.Error.Render("Request failed\n\n")+
+				ui.Theme.Muted.Render(m.data.Error),
+		)
+	}
 
-    var sb strings.Builder
+	// Normal content
+	var sb strings.Builder
+	sb.WriteString(m.renderStatusBar() + "\n\n")
+	sb.WriteString(m.renderTabBar() + "\n\n")
 
-    // Статус-бар
-    sb.WriteString(m.renderStatusBar() + "\n\n")
+	if m.activeTab == TabBody {
+		sb.WriteString(m.bodyVP.View())
+	} else {
+		sb.WriteString(m.headersVP.View())
+	}
 
-    // Tab bar
-    sb.WriteString(m.renderTabBar() + "\n\n")
-
-    // Контент
-    if m.activeTab == TabBody {
-        sb.WriteString(m.bodyVP.View())
-    } else {
-        sb.WriteString(m.headersVP.View())
-    }
-
-    return sb.String()
+	return sb.String()
 }
 
 func (m Model) renderStatusBar() string {
-    statusStyle := ui.StatusStyle(m.data.StatusCode)
-    status := statusStyle.Render(m.data.StatusText)
-    duration := ui.Theme.Muted.Render(FormatDuration(m.data.DurationMs))
-    size := ui.Theme.Muted.Render(FormatBytes(m.data.SizeBytes))
-    sep := ui.Theme.Muted.Render("  │  ")
-    shortcut := ui.Theme.Muted.Render("←/→: switch Body/Headers")
+	statusStyle := ui.StatusStyle(0)
+	status := ""
+	duration := ui.Theme.Muted.Render("0ms")
+	size := ui.Theme.Muted.Render("0 B")
+	sep := ui.Theme.Muted.Render("  │  ")
+	shortcut := ui.Theme.Muted.Render("←/→: switch Body/Headers")
 
-    return fmt.Sprintf("  %s%s%s%s%s%s%s",
-        status, sep, duration, sep, size, sep, shortcut,
-    )
+	if m.data != nil {
+		statusStyle = ui.StatusStyle(m.data.StatusCode)
+		status = statusStyle.Render(m.data.StatusText)
+		duration = ui.Theme.Muted.Render(FormatDuration(m.data.DurationMs))
+		size = ui.Theme.Muted.Render(FormatBytes(m.data.SizeBytes))
+	}
+
+	return fmt.Sprintf("  %s%s%s%s%s%s%s",
+		status, sep, duration, sep, size, sep, shortcut,
+	)
 }
 
 func (m Model) renderTabBar() string {
-    tabs := []string{"Body", "Headers"}
-    var parts []string
-    for i, name := range tabs {
-        label := "[" + name + "]"
-        if ResponseTab(i) == m.activeTab {
-            parts = append(parts, ui.Theme.TabActive.Render(label))
-        } else {
-            parts = append(parts, ui.Theme.TabInactive.Render(label))
-        }
-    }
-    return "  " + strings.Join(parts, "  ")
+	tabs := []string{"Body", "Headers"}
+	var parts []string
+	for i, name := range tabs {
+		label := "[" + name + "]"
+		if ResponseTab(i) == m.activeTab {
+			parts = append(parts, ui.Theme.TabActive.Render(label))
+		} else {
+			parts = append(parts, ui.Theme.TabInactive.Render(label))
+		}
+	}
+	return "  " + strings.Join(parts, "  ")
 }
 
 // Width / Height для App.renderPanel

--- a/internal/responsedisplay/model.go
+++ b/internal/responsedisplay/model.go
@@ -1,58 +1,233 @@
 package responsedisplay
 
 import (
-    tea "github.com/charmbracelet/bubbletea"
-    "github.com/charmbracelet/bubbles/spinner"
-    "htui/internal/types"
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"htui/internal/types"
+	"htui/internal/ui"
 )
 
-// Model — заглушка панели ответа.
+// ResponseTab — вкладка ответа.
+type ResponseTab int
+
+const (
+	TabBody    ResponseTab = iota
+	TabHeaders
+)
+
+// Model — компонент отображения ответа.
 type Model struct {
-    w, h    int
-    spin    spinner.Model
-    loading bool
+	data      *types.ResponseData // nil = пустое состояние
+	loading   bool
+	activeTab ResponseTab
+
+	bodyVP    viewport.Model
+	headersVP viewport.Model
+	spinner   spinner.Model
+
+	focused bool
+	width   int
+	height  int
+	ready   bool // false пока не установлены размеры
 }
 
+// New создаёт пустой компонент ответа.
 func New() Model {
-    s := spinner.New()
-    return Model{spin: s}
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("62"))
+
+	return Model{
+		spinner: s,
+	}
 }
 
+func (m Model) Init() tea.Cmd {
+	return nil
+}
+
+// SetSize устанавливает размеры и инициализирует viewport.
 func (m Model) SetSize(w, h int) (Model, tea.Cmd) {
-    m.w, m.h = w, h
-    return m, nil
+	// Guard против нулевых размеров
+	if w < 5 || h < 5 {
+		m.width = w
+		m.height = h
+		m.ready = true
+		return m, nil
+	}
+
+	m.width = w
+	m.height = h
+	m.ready = true
+
+	// Статус-бар: 2 строки. Tab bar: 2 строки. Отступы: 2 строки.
+	const reservedLines = 6
+	vpHeight := h - reservedLines
+	if vpHeight < 1 {
+		vpHeight = 1
+	}
+
+	m.bodyVP = viewport.New(w, vpHeight)
+	m.headersVP = viewport.New(w, vpHeight)
+
+	// Перезаполнить viewport если данные уже есть
+	if m.data != nil {
+		m.bodyVP.SetContent(FormatBody(*m.data))
+		m.headersVP.SetContent(FormatHeaders(m.data.Headers))
+	}
+	return m, nil
+}
+
+// SetLoading включает/выключает спиннер.
+func (m Model) SetLoading(loading bool) Model {
+	m.loading = loading
+	return m
+}
+
+// SetResponse загружает данные ответа и обновляет viewport.
+func (m Model) SetResponse(data types.ResponseData) Model {
+	m.data = &data
+	m.loading = false
+
+	if m.ready {
+		m.bodyVP.SetContent(FormatBody(data))
+		m.headersVP.SetContent(FormatHeaders(data.Headers))
+		m.bodyVP.GotoTop()
+		m.headersVP.GotoTop()
+	}
+	return m
+}
+
+// UpdateSpinner обновляет спиннер (вызывается из root App при spinner.TickMsg).
+func (m Model) UpdateSpinner(msg tea.Msg) (Model, tea.Cmd) {
+	var cmd tea.Cmd
+	m.spinner, cmd = m.spinner.Update(msg)
+	return m, cmd
+}
+
+// SpinnerCmd возвращает команду для запуска спиннера.
+func (m Model) SpinnerCmd() tea.Cmd {
+	return m.spinner.Tick
 }
 
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
-    // В Task 05 логика не важна
-    _ = msg
-    return m, nil
-}
+	if !m.ready {
+		return m, nil
+	}
 
-func (m Model) UpdateSpinner(msg spinner.TickMsg) (Model, tea.Cmd) {
-    var cmd tea.Cmd
-    m.spin, cmd = m.spin.Update(msg)
-    return m, cmd
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "tab":
+			if m.activeTab == TabBody {
+				m.activeTab = TabHeaders
+			} else {
+				m.activeTab = TabBody
+			}
+			return m, nil
+		}
+		// Прокрутка активного viewport
+		var cmd tea.Cmd
+		if m.activeTab == TabBody {
+			m.bodyVP, cmd = m.bodyVP.Update(msg)
+		} else {
+			m.headersVP, cmd = m.headersVP.Update(msg)
+		}
+		return m, cmd
+	}
+
+	// Другие сообщения (например WindowSizeMsg переданный повторно)
+	var cmd tea.Cmd
+	if m.activeTab == TabBody {
+		m.bodyVP, cmd = m.bodyVP.Update(msg)
+	} else {
+		m.headersVP, cmd = m.headersVP.Update(msg)
+	}
+	return m, cmd
 }
 
 func (m Model) View() string {
-    if m.loading {
-        return "Loading response..."
-    }
-    return "Response"
+	if !m.ready {
+		return lipgloss.Place(
+			m.width, m.height,
+			lipgloss.Center, lipgloss.Center,
+			ui.Theme.Muted.Render("Loading..."),
+		)
+	}
+
+	if m.loading {
+		return lipgloss.Place(
+			m.width, m.height,
+			lipgloss.Center, lipgloss.Center,
+			m.spinner.View()+"  Sending request...",
+		)
+	}
+
+	if m.data == nil {
+		return lipgloss.Place(
+			m.width, m.height,
+			lipgloss.Center, lipgloss.Center,
+			ui.Theme.Muted.Render("Press ")+
+				ui.Theme.Highlight.Render("ctrl+enter")+
+				ui.Theme.Muted.Render(" to send a request.\n\nResponse will appear here."),
+		)
+	}
+
+	if m.data.IsError() {
+		return lipgloss.Place(
+			m.width, m.height,
+			lipgloss.Center, lipgloss.Center,
+			ui.Theme.Error.Render("Request failed\n\n")+
+				ui.Theme.Muted.Render(m.data.Error),
+		)
+	}
+
+	var sb strings.Builder
+
+	// Статус-бар
+	sb.WriteString(m.renderStatusBar() + "\n\n")
+
+	// Tab bar
+	sb.WriteString(m.renderTabBar() + "\n\n")
+
+	// Контент
+	if m.activeTab == TabBody {
+		sb.WriteString(m.bodyVP.View())
+	} else {
+		sb.WriteString(m.headersVP.View())
+	}
+
+	return sb.String()
 }
 
-func (m Model) Width() int  { return m.w }
-func (m Model) Height() int { return m.h }
-
-// SetResponse — заглушка установки ответа.
-func (m Model) SetResponse(_ types.ResponseData) Model {
-    m.loading = false
-    return m
+func (m Model) renderStatusBar() string {
+	statusStyle := ui.StatusStyle(m.data.StatusCode)
+	status := statusStyle.Render(m.data.StatusText)
+	duration := ui.Theme.Muted.Render(FormatDuration(m.data.DurationMs))
+	size := ui.Theme.Muted.Render(FormatBytes(m.data.SizeBytes))
+	sep := ui.Theme.Muted.Render("  │  ")
+	return fmt.Sprintf("  %s%s%s%s%s", status, sep, duration, sep, size)
 }
 
-// SetLoading — заглушка включения/выключения загрузки.
-func (m Model) SetLoading(loading bool) Model {
-    m.loading = loading
-    return m
+func (m Model) renderTabBar() string {
+	tabs := []string{"Body", "Headers"}
+	var parts []string
+	for i, name := range tabs {
+		if ResponseTab(i) == m.activeTab {
+			parts = append(parts, ui.Theme.TabActive.Render(name))
+		} else {
+			parts = append(parts, ui.Theme.TabInactive.Render(name))
+		}
+	}
+	return "  " + strings.Join(parts, "  ")
 }
+
+// Width / Height для App.renderPanel
+func (m Model) Width() int  { return m.width }
+func (m Model) Height() int { return m.height }

--- a/internal/sidebar/model.go
+++ b/internal/sidebar/model.go
@@ -71,10 +71,9 @@ func New(requests []types.SavedRequest) Model {
         Foreground(lipgloss.Color("62"))
 
     l := list.New(toListItems(requests), delegate, 0, 0)
-    l.Title = "Requests"
+    l.SetShowTitle(false)
     l.SetShowStatusBar(false)
     l.SetFilteringEnabled(false) // используем свою фильтрацию
-    l.Styles.Title = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("62"))
 
     si := textinput.New()
     si.Placeholder = "Search..."
@@ -161,10 +160,12 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 func (m Model) View() string {
     if m.searching {
-        return lipgloss.JoinVertical(lipgloss.Left,
+        searchView := lipgloss.JoinVertical(lipgloss.Left,
             ui.Theme.Highlight.Render("Search: ")+m.search.View(),
             m.list.View(),
         )
+        helpText := ui.Theme.Muted.Render("\n  [esc] cancel  [/] search")
+        return lipgloss.JoinVertical(lipgloss.Left, searchView, helpText)
     }
 
     if len(m.requests) == 0 {
@@ -174,7 +175,10 @@ func (m Model) View() string {
                 ui.Theme.Muted.Render(" to create one."))
     }
 
-    return m.list.View()
+    // Render help at bottom, list above
+    listView := m.list.View()
+    helpText := ui.Theme.Muted.Render("\n  [n] new  [p] POST  [u] PUT  [h] PATCH\n  [d] dup  [del] delete  [/] search")
+    return lipgloss.JoinVertical(lipgloss.Left, listView, helpText)
 }
 
 // --- Публичные методы для App ---
@@ -183,8 +187,9 @@ func (m Model) View() string {
 func (m Model) SetSize(w, h int) (Model, tea.Cmd) {
     m.width = w
     m.height = h
+    // Leave space for help text at bottom (3 lines)
     m.list.SetWidth(w)
-    m.list.SetHeight(h)
+    m.list.SetHeight(h - 3)
     return m, nil
 }
 

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -60,11 +60,12 @@ func ComputePanelDimensions(w, h int, mode LayoutMode) PanelDimensions {
     case LayoutNarrow:
         sidebarW := w * 30 / 100
         contentW := w - sidebarW
-        contentH := h / 2
+        editorH := h * 2 / 3
+        responseH := h - editorH
         return PanelDimensions{
             Sidebar:  PanelSize{sidebarW - borderSize, h - borderSize},
-            Editor:   PanelSize{contentW - borderSize, contentH - borderSize},
-            Response: PanelSize{contentW - borderSize, h - contentH - borderSize},
+            Editor:   PanelSize{contentW - borderSize, editorH - borderSize},
+            Response: PanelSize{contentW - borderSize, responseH - borderSize},
         }
 
     default: // LayoutMinimal


### PR DESCRIPTION
что сделано
- реализовано сидирование трёх демо-запросов при первом запуске:
  1. Simple GET (jsonplaceholder)
  2. Create POST (jsonplaceholder)
  3. Bearer Auth (httpbin)
- автовыбор первого запроса в editor при первом запуске
- показ empty state в респонсс подсказкой "Press ctrl+enter to send request"
- улучшено отображение респонс:
  - короткие сообщения при пустом теле
  - правильное центрирование текста
- добавлены проверки идемпотентности: повторный запуск не создаёт дубликаты

как проверить
1. Удалить все данные приложения (имитация первого запуска):
   rm -rf ~/.config/htui/