### PR TITLE
fix: right panel form not fully rendered in terminal UI (#8)

### DIFF
--- a/internal/requesteditor/model.go
+++ b/internal/requesteditor/model.go
@@ -4,7 +4,7 @@ import (
     "fmt"
     "strings"
     "time"
-
+    "github.com/charmbracelet/lipgloss"
     "github.com/charmbracelet/bubbles/textarea"
     "github.com/charmbracelet/bubbles/textinput"
     tea "github.com/charmbracelet/bubbletea"
@@ -446,15 +446,16 @@ func (m Model) View() string {
     sb.WriteString(m.renderTabBar() + "\n")
 
     sb.WriteString(m.renderTabContent())
-
-    hint := ui.Theme.Muted.Render("  enter send  ctrl+s save as new  ctrl+u focus url")
-    if m.dirty {
-        hint = ui.Theme.Muted.Render("  enter send  ctrl+s save as new  ctrl+u focus url  ") +
-            ui.Theme.Error.Render("● unsaved")
-    }
-    sb.WriteString("\n" + hint)
-
-    return sb.String()
+hint := ui.Theme.Muted.Render("  enter send  ctrl+s save as new  ctrl+u focus url")
+if m.dirty {
+    hint = ui.Theme.Muted.Render("  enter send  ctrl+s save as new  ctrl+u focus url  ") +
+        ui.Theme.Error.Render("● unsaved")
+}
+if m.width > 0 {
+    hint = lipgloss.NewStyle().MaxWidth(m.width).Render(hint)
+}
+sb.WriteString("\n" + hint)
+return sb.String()
 }
 
 func (m Model) renderMethodSelector() string {

--- a/internal/responsedisplay/model.go
+++ b/internal/responsedisplay/model.go
@@ -224,9 +224,13 @@ func (m Model) renderStatusBar() string {
 		size = ui.Theme.Muted.Render(FormatBytes(m.data.SizeBytes))
 	}
 
-	return fmt.Sprintf("  %s%s%s%s%s%s%s",
-		status, sep, duration, sep, size, sep, shortcut,
-	)
+	bar := fmt.Sprintf("  %s%s%s%s%s%s%s",
+    status, sep, duration, sep, size, sep, shortcut,
+)
+if m.width > 0 {
+    bar = lipgloss.NewStyle().MaxWidth(m.width).Render(bar)
+}
+return bar
 }
 
 func (m Model) renderTabBar() string {


### PR DESCRIPTION
Closes #8

Строки фиксированной длины (hint в редакторе и статус-бар в панели ответа) 
не учитывали ширину панели и выходили за её правый край.

Добавлен MaxWidth(m.width) через lipgloss, чтобы текст обрезался 
по доступной ширине панели.