### PR TITLE
feat: add curl export (ctrl+e)

### DIFF
--- a/internal/app/keymap.go
+++ b/internal/app/keymap.go
@@ -1,6 +1,8 @@
 package app
 
-import "github.com/charmbracelet/bubbles/key"
+import (
+	"github.com/charmbracelet/bubbles/key"
+)
 
 // KeyMap содержит все глобальные горячие клавиши приложения.
 type KeyMap struct {
@@ -14,6 +16,7 @@ type KeyMap struct {
     Delete    key.Binding
     Help      key.Binding
     Quit      key.Binding
+    CurlExport key.Binding
 }
 
 // DefaultKeyMap — биндинги по умолчанию.
@@ -28,4 +31,5 @@ var DefaultKeyMap = KeyMap{
     Delete:    key.NewBinding(key.WithKeys("delete"),     key.WithHelp("del", "delete")),
     Help:      key.NewBinding(key.WithKeys("?"),          key.WithHelp("?", "help")),
     Quit:      key.NewBinding(key.WithKeys("q", "ctrl+c"),key.WithHelp("q", "quit")),
+    CurlExport: key.NewBinding(key.WithKeys("ctrl+e"),     key.WithHelp("ctrl+e", "copy as curl")),
 }

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -29,7 +29,7 @@ type ResponseReceivedMsg struct{ Data types.ResponseData }
 type RequestSavedMsg struct{ Request types.SavedRequest }
 type RequestCreatedMsg struct{ Request types.SavedRequest }
 type RequestDeletedMsg struct{ ID string }
-
+type CurlExportMsg struct{ Command string }
 // Сообщения потокового (streaming) получения ответа.
 type StreamStartMsg struct {
 	Meta types.ResponseMeta

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 
+	"htui/internal/curlexport"
 	"htui/internal/httpclient"
 	"htui/internal/requesteditor"
 	"htui/internal/sidebar"
@@ -60,6 +61,14 @@ func (m App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case key.Matches(msg, m.keys.Help):
 			m.showHelp = true
+			return m, nil
+		case key.Matches(msg, m.keys.CurlExport):
+			req := m.editor.BuildRequest()
+			curlCmd := curlexport.Build(req)
+			m.response = m.response.SetResponse(types.ResponseData{
+				Body: curlCmd,
+			})
+			m.focus = PanelResponse
 			return m, nil
 		case key.Matches(msg, m.keys.Quit):
 			m = m.cancelStream()

--- a/internal/curlexport/exporter.go
+++ b/internal/curlexport/exporter.go
@@ -1,0 +1,80 @@
+package curlexport
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"htui/internal/types"
+)
+
+
+func Build(r types.SavedRequest) string {
+	var sb strings.Builder
+
+	finalURL := buildURL(r)
+
+
+	if r.Method == "GET" {
+		sb.WriteString(fmt.Sprintf("curl \"%s\"", finalURL))
+	} else {
+		sb.WriteString(fmt.Sprintf("curl -X %s \"%s\"", r.Method, finalURL))
+	}
+
+	
+	if r.Auth.Type == types.AuthBearer && r.Auth.Token != "" {
+		sb.WriteString(fmt.Sprintf(" \\\n  -H \"Authorization: Bearer %s\"", r.Auth.Token))
+	}
+
+	
+	for _, h := range r.Headers {
+		if !h.Enabled || h.Key == "" {
+			continue
+		}
+		sb.WriteString(fmt.Sprintf(" \\\n  -H \"%s: %s\"", h.Key, h.Value))
+	}
+
+	
+	switch r.BodyMode {
+	case types.BodyModeJSON:
+		if r.Body != "" {
+			sb.WriteString(" \\\n  -H \"Content-Type: application/json\"")
+			sb.WriteString(fmt.Sprintf(" \\\n  -d '%s'", r.Body))
+		}
+	case types.BodyModeRawText:
+		if r.Body != "" {
+			sb.WriteString(fmt.Sprintf(" \\\n  -d '%s'", r.Body))
+		}
+	case types.BodyModeForm:
+		if r.Body != "" {
+			sb.WriteString(fmt.Sprintf(" \\\n  --data-urlencode '%s'", r.Body))
+		}
+	}
+
+	return sb.String()
+}
+
+
+func buildURL(r types.SavedRequest) string {
+	raw := r.URL
+	if raw == "" {
+		return ""
+	}
+	if !strings.Contains(raw, "://") {
+		raw = "https://" + raw
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+
+	q := u.Query()
+	for _, p := range r.Params {
+		if p.Enabled && p.Key != "" {
+			q.Set(p.Key, p.Value)
+		}
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
+}

--- a/internal/curlexport/exporter_test.go
+++ b/internal/curlexport/exporter_test.go
@@ -1,0 +1,110 @@
+package curlexport
+
+import (
+	"strings"
+	"testing"
+
+	"htui/internal/types"
+)
+
+func TestBuild_SimpleGET(t *testing.T) {
+	r := types.NewSavedRequest()
+	r.Method = "GET"
+	r.URL = "https://api.example.com/users"
+
+	got := Build(r)
+
+	if !strings.Contains(got, "curl \"https://api.example.com/users\"") {
+		t.Fatalf("unexpected output: %s", got)
+	}
+	if strings.Contains(got, "-X GET") {
+		t.Fatalf("GET should not include -X flag: %s", got)
+	}
+}
+
+func TestBuild_POSTWithJSON(t *testing.T) {
+	r := types.NewSavedRequest()
+	r.Method = "POST"
+	r.URL = "https://api.example.com/posts"
+	r.BodyMode = types.BodyModeJSON
+	r.Body = `{"title":"hello"}`
+
+	got := Build(r)
+
+	if !strings.Contains(got, "-X POST") {
+		t.Fatalf("expected -X POST: %s", got)
+	}
+	if !strings.Contains(got, "Content-Type: application/json") {
+		t.Fatalf("expected Content-Type header: %s", got)
+	}
+	if !strings.Contains(got, `{"title":"hello"}`) {
+		t.Fatalf("expected body: %s", got)
+	}
+}
+
+func TestBuild_BearerAuth(t *testing.T) {
+	r := types.NewSavedRequest()
+	r.Method = "GET"
+	r.URL = "https://api.example.com/me"
+	r.Auth = types.AuthConfig{Type: types.AuthBearer, Token: "mi-token-secreto"}
+
+	got := Build(r)
+
+	if !strings.Contains(got, "Authorization: Bearer mi-token-secreto") {
+		t.Fatalf("expected bearer token: %s", got)
+	}
+}
+
+func TestBuild_WithQueryParams(t *testing.T) {
+	r := types.NewSavedRequest()
+	r.Method = "GET"
+	r.URL = "https://api.example.com/search"
+	r.Params = []types.Param{
+		{Key: "q", Value: "golang", Enabled: true},
+		{Key: "page", Value: "1", Enabled: true},
+		{Key: "disabled", Value: "x", Enabled: false},
+	}
+
+	got := Build(r)
+
+	if !strings.Contains(got, "q=golang") {
+		t.Fatalf("expected query param q: %s", got)
+	}
+	if !strings.Contains(got, "page=1") {
+		t.Fatalf("expected query param page: %s", got)
+	}
+	if strings.Contains(got, "disabled") {
+		t.Fatalf("disabled param should not appear: %s", got)
+	}
+}
+
+func TestBuild_WithCustomHeaders(t *testing.T) {
+	r := types.NewSavedRequest()
+	r.Method = "GET"
+	r.URL = "https://api.example.com"
+	r.Headers = []types.Header{
+		{Key: "X-App-ID", Value: "123", Enabled: true},
+		{Key: "X-Ignored", Value: "abc", Enabled: false},
+	}
+
+	got := Build(r)
+
+	if !strings.Contains(got, "X-App-ID: 123") {
+		t.Fatalf("expected custom header: %s", got)
+	}
+	if strings.Contains(got, "X-Ignored") {
+		t.Fatalf("disabled header should not appear: %s", got)
+	}
+}
+
+func TestBuild_URLWithoutScheme(t *testing.T) {
+	r := types.NewSavedRequest()
+	r.Method = "GET"
+	r.URL = "api.example.com/users"
+
+	got := Build(r)
+
+	if !strings.Contains(got, "https://api.example.com/users") {
+		t.Fatalf("expected https scheme to be added: %s", got)
+	}
+}


### PR DESCRIPTION
## Что делает этот PR

Добавляет новую функцию: при нажатии `ctrl+e` текущий запрос конвертируется в команду `curl`. Результат отображается в панели ответа.

## Пример вывода

```bash
curl -X POST "https://api.example.com/posts" \
  -H "Authorization: Bearer my-token" \
  -H "Content-Type: application/json" \
  -d '{"title":"hello"}'
```

## Изменения
- `internal/curlexport/exporter.go` — основная логика
- `internal/curlexport/exporter_test.go` — 6 юнит-тестов
- `internal/app/keymap.go` — новый биндинг `ctrl+e`
- `internal/app/update.go` — обработчик новой клавиши
- `internal/app/model.go` — новый тип `CurlExportMsg`