### PR TITLE
feat: add request templates support

### DIFF
--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -29,6 +29,7 @@ type ResponseReceivedMsg struct{ Data types.ResponseData }
 type RequestSavedMsg struct{ Request types.SavedRequest }
 type RequestCreatedMsg struct{ Request types.SavedRequest }
 type RequestDeletedMsg struct{ ID string }
+type TemplateSavedMsg struct{ Request types.SavedRequest }
 
 // Сообщения потокового (streaming) получения ответа.
 type StreamStartMsg struct {
@@ -110,14 +111,19 @@ func New() (App, error) {
 		return App{}, err
 	}
 
+	templates, err := s.ListTemplates()
+	if err != nil {
+		return App{}, err
+	}
+
 	m := App{
 		store:  s,
 		client: httpclient.New(),
-		keys:   DefaultKeyMap, // <-- используем KeyMap из keymap.go
+		keys:   DefaultKeyMap,
 		focus:  PanelSidebar,
 	}
 
-	m.sidebar = sidebar.New(requests)
+	m.sidebar = sidebar.New(requests, templates)
 	m.editor = requesteditor.New()
 	m.response = responsedisplay.New()
 	// nil — использовать defaultSections() внутри ui.NewHelpModel,

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/spinner"
@@ -139,6 +140,18 @@ func (m App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, createRequestCmd(m.store, req)
 
+	case sidebar.TemplateSelectedMsg:
+		m = m.cancelStream()
+		newReq := msg.Template
+		newReq.ID = fmt.Sprintf("%d", now())
+		newReq.IsTemplate = false
+		newReq.CreatedAt = time.Time{}
+		newReq.UpdatedAt = time.Time{}
+		m.editor = m.editor.LoadRequest(newReq)
+		m.editor = m.editor.MarkDirty()
+		m.focus = PanelEditor
+		return m, nil
+
 	case RequestCreatedMsg:
 		m = m.cancelStream()
 		m.sidebar = m.sidebar.Reload(m.store)
@@ -167,9 +180,16 @@ func (m App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case requesteditor.SaveRequestMsg:
 		return m, saveRequestCmd(m.store, msg.Request)
 
+	case requesteditor.SaveAsTemplateMsg:
+		return m, saveTemplateCmd(m.store, msg.Request)
+
 	case RequestSavedMsg:
 		m.sidebar = m.sidebar.Reload(m.store)
 		m.editor = m.editor.Clear()
+		return m, nil
+
+	case TemplateSavedMsg:
+		m.sidebar = m.sidebar.Reload(m.store)
 		return m, nil
 
 	case RequestDeletedMsg:
@@ -277,6 +297,15 @@ func saveRequestCmd(s interface {
 	return func() tea.Msg {
 		_ = s.Save(r)
 		return RequestSavedMsg{Request: r}
+	}
+}
+
+func saveTemplateCmd(s interface {
+	Save(types.SavedRequest) error
+}, r types.SavedRequest) tea.Cmd {
+	return func() tea.Msg {
+		_ = s.Save(r)
+		return TemplateSavedMsg{Request: r}
 	}
 }
 

--- a/internal/requesteditor/model.go
+++ b/internal/requesteditor/model.go
@@ -38,6 +38,10 @@ const (
 
 type SendRequestMsg struct{ Request types.SavedRequest }
 type SaveRequestMsg struct{ Request types.SavedRequest }
+type SaveAsTemplateMsg struct{ Request types.SavedRequest }
+
+// clearFlashMsg сбрасывает flash-статус после таймера.
+type clearFlashMsg struct{}
 
 // --- Модель ---
 
@@ -65,6 +69,7 @@ type Model struct {
 	width          int
 	height         int
 	validationErrs []string // показываются под URL при ошибке
+	flashMsg       string   // кратковременное уведомление о сохранении
 }
 
 var bodyModes = []types.BodyMode{
@@ -178,6 +183,11 @@ func (m Model) CurrentID() string {
 	return m.current.ID
 }
 
+func (m Model) MarkDirty() Model {
+	m.dirty = true
+	return m
+}
+
 // BuildRequest собирает types.SavedRequest из текущего состояния полей.
 func (m Model) BuildRequest() types.SavedRequest {
 	r := m.current
@@ -204,6 +214,12 @@ func (m Model) BuildRequest() types.SavedRequest {
 func (m Model) Init() tea.Cmd { return nil }
 
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	switch msg.(type) {
+	case clearFlashMsg:
+		m.flashMsg = ""
+		return m, nil
+	}
+
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
@@ -221,15 +237,32 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		// Сохранение всегда как новый
 		case "ctrl+s":
 			req := m.BuildRequest()
-			// Генерируем новый уникальный ID
 			req.ID = fmt.Sprintf("%d", time.Now().UnixNano())
-			// Генерируем имя на основе метода и URL
 			method := types.HTTPMethods[m.methodIdx]
 			req.Name = method + " request"
 			req.CreatedAt = time.Now()
 			req.UpdatedAt = time.Now()
 			m.dirty = false
-			return m, func() tea.Msg { return SaveRequestMsg{Request: req} }
+			m.flashMsg = "✓ saved"
+			return m, tea.Batch(
+				func() tea.Msg { return SaveRequestMsg{Request: req} },
+				tea.Tick(2*time.Second, func(time.Time) tea.Msg { return clearFlashMsg{} }),
+			)
+
+		// Сохранение как шаблон (не очищает редактор)
+		case "ctrl+t":
+			req := m.BuildRequest()
+			req.ID = fmt.Sprintf("%d", time.Now().UnixNano())
+			method := types.HTTPMethods[m.methodIdx]
+			req.Name = method + " template"
+			req.IsTemplate = true
+			req.CreatedAt = time.Now()
+			req.UpdatedAt = time.Now()
+			m.flashMsg = "✓ template saved"
+			return m, tea.Batch(
+				func() tea.Msg { return SaveAsTemplateMsg{Request: req} },
+				tea.Tick(2*time.Second, func(time.Time) tea.Msg { return clearFlashMsg{} }),
+			)
 
 		// Переход к URL полю
 		case "ctrl+u":
@@ -447,9 +480,12 @@ func (m Model) View() string {
 
 	sb.WriteString(m.renderTabContent())
 
-	hint := ui.Theme.Muted.Render("  enter send  ctrl+s save as new  ctrl+u focus url")
-	if m.dirty {
-		hint = ui.Theme.Muted.Render("  enter send  ctrl+s save as new  ctrl+u focus url  ") +
+	hint := ui.Theme.Muted.Render("  enter send  ctrl+s save  ctrl+t template  ctrl+u url")
+	if m.flashMsg != "" {
+		hint = ui.Theme.Muted.Render("  enter send  ctrl+s save  ctrl+t template  ctrl+u url  ") +
+			ui.Theme.Success.Render(m.flashMsg)
+	} else if m.dirty {
+		hint = ui.Theme.Muted.Render("  enter send  ctrl+s save  ctrl+t template  ctrl+u url  ") +
 			ui.Theme.Error.Render("● unsaved")
 	}
 	sb.WriteString("\n" + hint)

--- a/internal/sidebar/model.go
+++ b/internal/sidebar/model.go
@@ -3,18 +3,20 @@ package sidebar
 import (
 	"strings"
 
+	"htui/internal/store"
+	"htui/internal/types"
+	"htui/internal/ui"
+
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"htui/internal/store"
-	"htui/internal/types"
-	"htui/internal/ui"
 )
 
 // --- Сообщения, эмитируемые sidebar вверх в App ---
 
 type RequestSelectedMsg struct{ Request types.SavedRequest }
+type TemplateSelectedMsg struct{ Template types.SavedRequest }
 type NewRequestMsg struct{}
 type NewRequestWithMethodMsg struct{ Method string }
 type DeleteRequestMsg struct{ ID string }
@@ -39,6 +41,24 @@ func (i requestItem) FilterValue() string {
 	return i.req.Name + " " + i.req.URL
 }
 
+// templateItem — элемент списка шаблонов (со звёздочкой в заголовке).
+type templateItem struct {
+	req types.SavedRequest
+}
+
+func (i templateItem) Title() string {
+	return "★ " + i.req.Name
+}
+
+func (i templateItem) Description() string {
+	return ui.MethodStyle(i.req.Method).Render(i.req.Method) +
+		"  " + shortURL(i.req.URL)
+}
+
+func (i templateItem) FilterValue() string {
+	return i.req.Name + " " + i.req.URL
+}
+
 // shortURL обрезает URL до отображаемой длины (убирает схему).
 func shortURL(raw string) string {
 	raw = strings.TrimPrefix(raw, "https://")
@@ -52,17 +72,19 @@ func shortURL(raw string) string {
 // --- Model ---
 
 type Model struct {
-	list      list.Model
-	search    textinput.Model
-	searching bool
-	requests  []types.SavedRequest // полный неотфильтрованный список
-	focused   bool
-	width     int
-	height    int
+	list         list.Model
+	search       textinput.Model
+	searching    bool
+	templateMode bool
+	requests     []types.SavedRequest // запросы (IsTemplate=false)
+	templates    []types.SavedRequest // шаблоны (IsTemplate=true)
+	focused      bool
+	width        int
+	height       int
 }
 
-// New создаёт Sidebar с начальным набором запросов.
-func New(requests []types.SavedRequest) Model {
+// New создаёт Sidebar с начальным набором запросов и шаблонов.
+func New(requests []types.SavedRequest, templates []types.SavedRequest) Model {
 	delegate := list.NewDefaultDelegate()
 	delegate.Styles.SelectedTitle = delegate.Styles.SelectedTitle.
 		Foreground(lipgloss.Color("255")).
@@ -83,9 +105,10 @@ func New(requests []types.SavedRequest) Model {
 	si.CharLimit = 100
 
 	return Model{
-		list:     l,
-		search:   si,
-		requests: requests,
+		list:      l,
+		search:    si,
+		requests:  requests,
+		templates: templates,
 	}
 }
 
@@ -94,6 +117,61 @@ func (m Model) Init() tea.Cmd { return nil }
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	var cmds []tea.Cmd
 
+	// Template mode: навигация по шаблонам
+	if m.templateMode {
+		if m.searching {
+			switch msg := msg.(type) {
+			case tea.KeyMsg:
+				switch msg.String() {
+				case "esc":
+					m.searching = false
+					m.search.SetValue("")
+					m.applyFilter("")
+					return m, nil
+				case "enter":
+					m.searching = false
+					return m, nil
+				default:
+					var c tea.Cmd
+					m.search, c = m.search.Update(msg)
+					cmds = append(cmds, c)
+					m.applyFilter(m.search.Value())
+					return m, tea.Batch(cmds...)
+				}
+			}
+		}
+
+		switch msg := msg.(type) {
+		case tea.KeyMsg:
+			switch msg.String() {
+			case "t", "esc":
+				m.templateMode = false
+				m.searching = false
+				m.search.SetValue("")
+				m.list.SetItems(toListItems(m.requests))
+				return m, nil
+			case "enter":
+				if item, ok := m.list.SelectedItem().(templateItem); ok {
+					return m, func() tea.Msg { return TemplateSelectedMsg{Template: item.req} }
+				}
+			case "delete", "backspace":
+				if item, ok := m.list.SelectedItem().(templateItem); ok {
+					return m, func() tea.Msg { return DeleteRequestMsg{ID: item.req.ID} }
+				}
+			case "/":
+				m.searching = true
+				m.search.Focus()
+				return m, textinput.Blink
+			}
+		}
+
+		var c tea.Cmd
+		m.list, c = m.list.Update(msg)
+		cmds = append(cmds, c)
+		return m, tea.Batch(cmds...)
+	}
+
+	// Search mode
 	if m.searching {
 		switch msg := msg.(type) {
 		case tea.KeyMsg:
@@ -114,13 +192,9 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				return m, tea.Batch(cmds...)
 			}
 		}
-		var c tea.Cmd
-		m.search, c = m.search.Update(msg)
-		cmds = append(cmds, c)
-		m.applyFilter(m.search.Value())
-		return m, tea.Batch(cmds...)
 	}
 
+	// Нормальный режим
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
@@ -128,23 +202,22 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			if item, ok := m.list.SelectedItem().(requestItem); ok {
 				return m, func() tea.Msg { return RequestSelectedMsg{Request: item.req} }
 			}
+		case "t":
+			m.templateMode = true
+			m.list.SetItems(toTemplateListItems(m.templates))
+			m.list.Select(0)
+			return m, nil
 		case "n":
-			// базовый новый запрос (GET) под Task 06
 			return m, func() tea.Msg { return NewRequestMsg{} }
 		case "p":
-			// новый POST-запрос
 			return m, func() tea.Msg { return NewRequestWithMethodMsg{Method: "POST"} }
 		case "u":
-			// новый PUT-запрос
 			return m, func() tea.Msg { return NewRequestWithMethodMsg{Method: "PUT"} }
 		case "h":
-			// новый PATCH-запрос
 			return m, func() tea.Msg { return NewRequestWithMethodMsg{Method: "PATCH"} }
 		case "o":
-			// новый OPTIONS-запрос
 			return m, func() tea.Msg { return NewRequestWithMethodMsg{Method: "OPTIONS"} }
 		case "e":
-			// новый HEAD-запрос
 			return m, func() tea.Msg { return NewRequestWithMethodMsg{Method: "HEAD"} }
 		case "d":
 			if item, ok := m.list.SelectedItem().(requestItem); ok {
@@ -168,6 +241,28 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 }
 
 func (m Model) View() string {
+	if m.templateMode {
+		var header string
+		if m.searching {
+			header = ui.Theme.Highlight.Render("Search: ") + m.search.View()
+		} else {
+			header = ui.Theme.Highlight.Render("★ TEMPLATES") +
+				ui.Theme.Muted.Render("  [t/esc] назад")
+		}
+
+		if len(m.templates) == 0 && !m.searching {
+			emptyMsg := lipgloss.NewStyle().Padding(2, 2).
+				Render(ui.Theme.Muted.Render("Нет шаблонов.\n\nВ редакторе нажмите ") +
+					ui.Theme.Highlight.Render("[ctrl+t]") +
+					ui.Theme.Muted.Render(" чтобы сохранить."))
+			helpText := ui.Theme.Muted.Render("\n  [t/esc] назад")
+			return lipgloss.JoinVertical(lipgloss.Left, header, emptyMsg, helpText)
+		}
+
+		helpText := ui.Theme.Muted.Render("\n  [enter] открыть  [del] удалить  [/] поиск  [t/esc] назад")
+		return lipgloss.JoinVertical(lipgloss.Left, header, m.list.View(), helpText)
+	}
+
 	if m.searching {
 		searchView := lipgloss.JoinVertical(lipgloss.Left,
 			ui.Theme.Highlight.Render("Search: ")+m.search.View(),
@@ -184,9 +279,8 @@ func (m Model) View() string {
 				ui.Theme.Muted.Render(" to create one."))
 	}
 
-	// Render help at bottom, list above
 	listView := m.list.View()
-	helpText := ui.Theme.Muted.Render("\n  [n] new  [p] POST  [u] PUT  [h] PATCH\n  [o] OPTIONS  [e] HEAD\n  [d] dup  [del] delete  [/] search")
+	helpText := ui.Theme.Muted.Render("\n  [n] new  [p] POST  [u] PUT  [h] PATCH\n  [o] OPTIONS  [e] HEAD\n  [d] dup  [del] delete  [/] search  [t] templates")
 	return lipgloss.JoinVertical(lipgloss.Left, listView, helpText)
 }
 
@@ -196,9 +290,9 @@ func (m Model) View() string {
 func (m Model) SetSize(w, h int) (Model, tea.Cmd) {
 	m.width = w
 	m.height = h
-	// Leave space for help text at bottom (3 lines)
+	// Leave space for help text at bottom (4 lines: 1 blank + 3 text)
 	m.list.SetWidth(max(w, 0))
-	m.list.SetHeight(max(h-3, 0))
+	m.list.SetHeight(max(h-4, 0))
 	return m, nil
 }
 
@@ -218,30 +312,53 @@ func (m Model) SelectFirst() Model {
 	return m
 }
 
-// Reload перезагружает список запросов из store.
+// Reload перезагружает список запросов и шаблонов из store.
 func (m Model) Reload(s store.Store) Model {
 	requests, err := s.List()
-	if err != nil {
-		return m
+	if err == nil {
+		m.requests = requests
 	}
-	m.requests = requests
-	m.applyFilter(m.search.Value())
+	templates, err := s.ListTemplates()
+	if err == nil {
+		m.templates = templates
+	}
+	if m.templateMode {
+		m.list.SetItems(toTemplateListItems(m.templates))
+	} else {
+		m.applyFilter(m.search.Value())
+	}
 	return m
 }
 
 // --- Внутренние хелперы ---
 
 func (m *Model) applyFilter(query string) {
+	var source []types.SavedRequest
+	if m.templateMode {
+		source = m.templates
+	} else {
+		source = m.requests
+	}
+
 	if query == "" {
-		m.list.SetItems(toListItems(m.requests))
+		if m.templateMode {
+			m.list.SetItems(toTemplateListItems(source))
+		} else {
+			m.list.SetItems(toListItems(source))
+		}
 		return
 	}
+
 	q := strings.ToLower(query)
 	var filtered []list.Item
-	for _, r := range m.requests {
+	for _, r := range source {
 		if strings.Contains(strings.ToLower(r.Name), q) ||
 			strings.Contains(strings.ToLower(r.URL), q) {
-			filtered = append(filtered, requestItem{r})
+			if m.templateMode {
+				filtered = append(filtered, templateItem{r})
+			} else {
+				filtered = append(filtered, requestItem{r})
+			}
 		}
 	}
 	m.list.SetItems(filtered)
@@ -251,6 +368,14 @@ func toListItems(requests []types.SavedRequest) []list.Item {
 	items := make([]list.Item, len(requests))
 	for i, r := range requests {
 		items[i] = requestItem{r}
+	}
+	return items
+}
+
+func toTemplateListItems(templates []types.SavedRequest) []list.Item {
+	items := make([]list.Item, len(templates))
+	for i, r := range templates {
+		items[i] = templateItem{r}
 	}
 	return items
 }

--- a/internal/sidebar/model_test.go
+++ b/internal/sidebar/model_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestViewFitsAssignedHeight(t *testing.T) {
-	m := New(types.DemoRequests()).SelectFirst()
+	m := New(types.DemoRequests(), nil).SelectFirst()
 	m, _ = m.SetSize(32, 18)
 
 	if got := lipgloss.Height(m.View()); got > m.Height() {

--- a/internal/store/files.go
+++ b/internal/store/files.go
@@ -58,6 +58,9 @@ func (s *FileStore) List() ([]types.SavedRequest, error) {
 			log.Printf("warn: corrupt JSON in %s, skipping: %v", e.Name(), err)
 			continue
 		}
+		if r.IsTemplate {
+			continue
+		}
 		requests = append(requests, r)
 	}
 
@@ -67,6 +70,40 @@ func (s *FileStore) List() ([]types.SavedRequest, error) {
 	})
 
 	return requests, nil
+}
+
+func (s *FileStore) ListTemplates() ([]types.SavedRequest, error) {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read requests dir: %w", err)
+	}
+
+	var templates []types.SavedRequest
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(s.dir, e.Name()))
+		if err != nil {
+			log.Printf("warn: cannot read %s: %v", e.Name(), err)
+			continue
+		}
+		var r types.SavedRequest
+		if err := json.Unmarshal(data, &r); err != nil {
+			log.Printf("warn: corrupt JSON in %s, skipping: %v", e.Name(), err)
+			continue
+		}
+		if !r.IsTemplate {
+			continue
+		}
+		templates = append(templates, r)
+	}
+
+	sort.Slice(templates, func(i, j int) bool {
+		return templates[i].UpdatedAt.After(templates[j].UpdatedAt)
+	})
+
+	return templates, nil
 }
 
 func (s *FileStore) Get(id string) (types.SavedRequest, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -5,8 +5,11 @@ import "htui/internal/types"
 // Store — интерфейс хранилища запросов.
 // Позволяет подменять реализацию в тестах.
 type Store interface {
-	// List возвращает все запросы, отсортированные по UpdatedAt desc.
+	// List возвращает все запросы (не шаблоны), отсортированные по UpdatedAt desc.
 	List() ([]types.SavedRequest, error)
+
+	// ListTemplates возвращает все шаблоны, отсортированные по UpdatedAt desc.
+	ListTemplates() ([]types.SavedRequest, error)
 
 	// Get возвращает запрос по ID или ошибку если не найден.
 	Get(id string) (types.SavedRequest, error)

--- a/internal/types/request.go
+++ b/internal/types/request.go
@@ -42,8 +42,9 @@ type SavedRequest struct {
 	Headers   []Header   `json:"headers"`
 	BodyMode  BodyMode   `json:"body_mode"`
 	Body      string     `json:"body"`
-	Auth      AuthConfig `json:"auth"`
-	CreatedAt time.Time  `json:"created_at"`
+	Auth       AuthConfig `json:"auth"`
+	IsTemplate bool       `json:"is_template,omitempty"`
+	CreatedAt  time.Time  `json:"created_at"`
 	UpdatedAt time.Time  `json:"updated_at"`
 }
 

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -44,6 +44,7 @@ var Theme = struct {
 	Bold        lipgloss.Style
 	Muted       lipgloss.Style
 	Error       lipgloss.Style
+	Success     lipgloss.Style
 	Highlight   lipgloss.Style
 	TabActive   lipgloss.Style
 	TabInactive lipgloss.Style
@@ -72,6 +73,7 @@ var Theme = struct {
 	Bold:        lipgloss.NewStyle().Bold(true),
 	Muted:       lipgloss.NewStyle().Foreground(colorMuted),
 	Error:       lipgloss.NewStyle().Foreground(colorRed),
+	Success:     lipgloss.NewStyle().Foreground(colorGreen),
 	Highlight:   lipgloss.NewStyle().Foreground(colorHighlight),
 	TabActive:   lipgloss.NewStyle().Foreground(colorHighlight).Bold(true).Underline(true),
 	TabInactive: lipgloss.NewStyle().Foreground(colorMuted),


### PR DESCRIPTION
## Summary
- add template persistence support via `is_template` so regular requests and templates are stored together but listed separately
- implement templates mode in sidebar toggled by `t`, with open/search/delete and empty-state hint
- add `ctrl+t` in request editor to save current request as a template and show a short success flash
- load selected template into editor as a new draft request (new id, not marked as template)

## Why
This makes repeated API scenarios faster to run during demos and labs: users can keep reusable request blueprints and instantiate them quickly without recreating fields every time.

## Test plan
- [x] In sidebar, press `t` to switch to templates list and `t`/`esc` to go back
- [x] In request editor, press `ctrl+t` and confirm template appears in templates list
- [x] Open template from sidebar and verify editor is filled with a new editable request draft
- [x] Confirm templates are not shown in the regular requests list
- [x] Run `go test ./...`