### PR TITLE
fix: right panel layout

### DIFF
--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -51,9 +51,11 @@ func (m App) renderPanel(content string, active bool, w, h int) string {
 		return ""
 	}
 
-	style := ui.Theme.InactiveBorder
-	if active {
-		style = ui.Theme.ActiveBorder
-	}
-	return style.Width(w).Height(h).Render(content)
+
+content = ui.FitBlock(content, w, h)
+
+style := ui.Theme.InactiveBorder
+if active {
+    style = ui.Theme.ActiveBorder
 }
+return style.Render(content) } 

--- a/internal/sidebar/model.go
+++ b/internal/sidebar/model.go
@@ -3,13 +3,14 @@ package sidebar
 import (
 	"strings"
 
+	"htui/internal/store"
+	"htui/internal/types"
+	"htui/internal/ui"
+
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"htui/internal/store"
-	"htui/internal/types"
-	"htui/internal/ui"
 )
 
 // --- Сообщения, эмитируемые sidebar вверх в App ---
@@ -60,6 +61,7 @@ type Model struct {
 	width     int
 	height    int
 }
+const sidebarChromeHeight = 4
 
 // New создаёт Sidebar с начальным набором запросов.
 func New(requests []types.SavedRequest) Model {
@@ -173,21 +175,22 @@ func (m Model) View() string {
 			ui.Theme.Highlight.Render("Search: ")+m.search.View(),
 			m.list.View(),
 		)
-		helpText := ui.Theme.Muted.Render("\n  [esc] cancel  [/] search")
-		return lipgloss.JoinVertical(lipgloss.Left, searchView, helpText)
+		helpText := ui.Theme.Muted.Render(" [esc] cancel  [/] search")
+		return m.fit(lipgloss.JoinVertical(lipgloss.Left, searchView, helpText))
 	}
 
 	if len(m.requests) == 0 {
-		return lipgloss.NewStyle().Padding(2, 2).
-			Render(ui.Theme.Muted.Render("No saved requests.\n\nPress ") +
-				ui.Theme.Highlight.Render("[n]") +
-				ui.Theme.Muted.Render(" to create one."))
-	}
+    view := lipgloss.NewStyle().Padding(2, 2).
+        Render(ui.Theme.Muted.Render("No saved requests.\n\nPress ") +
+            ui.Theme.Highlight.Render("[n]") +
+            ui.Theme.Muted.Render(" to create one."))
+    return m.fit(view)
+}
 
 	// Render help at bottom, list above
 	listView := m.list.View()
-	helpText := ui.Theme.Muted.Render("\n  [n] new  [p] POST  [u] PUT  [h] PATCH\n  [o] OPTIONS  [e] HEAD\n  [d] dup  [del] delete  [/] search")
-	return lipgloss.JoinVertical(lipgloss.Left, listView, helpText)
+	helpText := ui.Theme.Muted.Render("  [n] new  [p] POST  [u] PUT  [h] PATCH\n  [o] OPTIONS  [e] HEAD\n  [d] dup  [del] delete  [/] search")
+    return m.fit(lipgloss.JoinVertical(lipgloss.Left, listView, helpText))	
 }
 
 // --- Публичные методы для App ---
@@ -198,10 +201,15 @@ func (m Model) SetSize(w, h int) (Model, tea.Cmd) {
 	m.height = h
 	// Leave space for help text at bottom (3 lines)
 	m.list.SetWidth(max(w, 0))
-	m.list.SetHeight(max(h-3, 0))
+	m.list.SetHeight(max(h-sidebarChromeHeight, 0))
 	return m, nil
 }
-
+func (m Model) fit(view string) string {
+	if m.width <= 0 || m.height <= 0 {
+		return view
+	}
+	return ui.FitBlock(view, m.width, m.height)
+}
 // Width / Height для renderPanel в app/view.go
 func (m Model) Width() int  { return m.width }
 func (m Model) Height() int { return m.height }

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -24,6 +24,7 @@ const (
 	shellBorderSize        = 2
 	panelBorderSize        = 2
 	panelGap               = 0
+	minBodyHeight          = 1
 	minSidebarFrameWidth   = 18
 	maxSidebarFrameWidth   = 34
 	minRightFrameWidth     = 30
@@ -60,7 +61,7 @@ var asciiHeader = strings.TrimSpace(`
 |  _  |  | |  | |_| | | |
 |_| |_|  |_|   \___/ |___|
 `)
-
+var asciiHeaderWidth = lipgloss.Width(asciiHeader)
 // ComputeLayout определяет режим раскладки по ширине терминала.
 func ComputeLayout(width int) LayoutMode {
 	_ = width
@@ -72,14 +73,15 @@ func ComputeShellDimensions(w, h int) ShellDimensions {
 	innerW := max(w-shellBorderSize, 1)
 	innerH := max(h-shellBorderSize, 1)
 
-	useASCIIHeader := innerW >= 42 && innerH >= 18
+	useASCIIHeader := innerW >=  asciiHeaderWidth && innerH >= 18
 	headerHeight := lipgloss.Height(RenderHeader(innerW, useASCIIHeader))
+	bodyHeight := max(innerH-headerHeight, minBodyHeight)
 
 	return ShellDimensions{
 		Width:          innerW,
 		Height:         innerH,
 		BodyWidth:      innerW,
-		BodyHeight:     max(innerH-headerHeight, 1),
+		BodyHeight:     bodyHeight,
 		UseASCIIHeader: useASCIIHeader,
 	}
 }
@@ -111,27 +113,49 @@ func ComputePanelDimensions(w, h int, mode LayoutMode) PanelDimensions {
 // RenderLayout собирает финальный вид из трёх строк-компонентов.
 // RenderHeader renders the HTUI header inside the shared frame.
 func RenderHeader(width int, useASCIIHeader bool) string {
+	if width <= 0 {
+		return ""
+	}
 	if useASCIIHeader {
-		art := lipgloss.PlaceHorizontal(width, lipgloss.Center, Theme.HeaderArt.Render(asciiHeader))
-		subtitle := lipgloss.PlaceHorizontal(width, lipgloss.Center, Theme.HeaderSubtitle.Render("HTTP terminal UI"))
+		
+		art := Theme.HeaderArt.Render(lipgloss.PlaceHorizontal(width, lipgloss.Center, asciiHeader))
+		subtitle := Theme.HeaderSubtitle.Render(lipgloss.PlaceHorizontal(width, lipgloss.Center, "HTTP terminal UI"))
 		return lipgloss.JoinVertical(lipgloss.Left, art, subtitle)
 	}
 
-	title := lipgloss.PlaceHorizontal(width, lipgloss.Center, Theme.HeaderArt.Render("HTUI"))
-	subtitle := lipgloss.PlaceHorizontal(width, lipgloss.Center, Theme.HeaderSubtitle.Render("HTTP terminal UI"))
+	title := Theme.HeaderArt.Render(lipgloss.PlaceHorizontal(width, lipgloss.Center, "HTUI"))
+	subtitle := Theme.HeaderSubtitle.Render(lipgloss.PlaceHorizontal(width, lipgloss.Center, "HTTP terminal UI"))
 	return lipgloss.JoinVertical(lipgloss.Left, title, subtitle)
 }
 
 // RenderShell wraps the header and panels into one outer window.
 func RenderShell(shell ShellDimensions, body string) string {
 	header := RenderHeader(shell.Width, shell.UseASCIIHeader)
+	body = lipgloss.NewStyle().
+		Width(shell.BodyWidth).
+		Height(shell.BodyHeight).
+		MaxWidth(shell.BodyWidth).
+		MaxHeight(shell.BodyHeight).
+		Render(body)
 	content := lipgloss.JoinVertical(
 		lipgloss.Left,
 		header,
-		lipgloss.Place(shell.BodyWidth, shell.BodyHeight, lipgloss.Left, lipgloss.Top, body),
+		body,
 	)
-
 	return Theme.ShellBorder.Width(shell.Width).Height(shell.Height).Render(content)
+}
+// FitBlock constrains content to an exact terminal-cell rectangle.
+func FitBlock(content string, width, height int) string {
+	if width <= 0 || height <= 0 {
+		return ""
+	}
+
+	return lipgloss.NewStyle().
+		Width(width).
+		Height(height).
+		MaxWidth(width).
+		MaxHeight(height).
+		Render(content)
 }
 
 func RenderLayout(mode LayoutMode, sidebar, editor, response string) string {

--- a/internal/ui/layout_test.go
+++ b/internal/ui/layout_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
@@ -27,6 +28,15 @@ func TestComputeShellDimensionsSwitchesHeaderMode(t *testing.T) {
 	}
 }
 
+func TestRenderHeaderFitsShellWidth(t *testing.T) {
+	header := RenderHeader(32, true)
+	for _, line := range strings.Split(header, "\n") {
+		if got := lipgloss.Width(line); got != 32 {
+			t.Fatalf("header line width mismatch: got %d, want 32; line %q", got, line)
+		}
+	}
+}
+
 func TestComputePanelDimensionsFillStableGrid(t *testing.T) {
 	shell := ComputeShellDimensions(140, 42)
 	dims := ComputePanelDimensions(shell.BodyWidth, shell.BodyHeight, LayoutNarrow)
@@ -45,6 +55,17 @@ func TestComputePanelDimensionsFillStableGrid(t *testing.T) {
 
 	if dims.Sidebar.Height+panelBorderSize != shell.BodyHeight {
 		t.Fatalf("sidebar should span full shell body height")
+	}
+}
+
+func TestFitBlockConstrainsContent(t *testing.T) {
+	rendered := FitBlock("this line is longer than the box\nline 2\nline 3", 8, 2)
+
+	if got := lipgloss.Width(rendered); got != 8 {
+		t.Fatalf("unexpected block width: got %d, want 8", got)
+	}
+	if got := lipgloss.Height(rendered); got != 2 {
+		t.Fatalf("unexpected block height: got %d, want 2", got)
 	}
 }
 


### PR DESCRIPTION
Closes #8

Fixed right panel clipping issue where content was overflowing panel boundaries.

- Added FitBlock() utility to constrain content to exact terminal-cell dimensions
- Updated renderPanel to use FitBlock before applying border styles
- Fixed sidebar chrome height calculation with sidebarChromeHeight constant
- Fixed RenderShell to use lipgloss style constraints instead of lipgloss.Place
- Fixed RenderHeader to handle zero-width terminals